### PR TITLE
chore: don't run GH action tests if no contracts changed

### DIFF
--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - "packages/contracts/**"
 
 jobs:
   test:


### PR DESCRIPTION
eBTC test pipeline takes 40+ minutes to complete. This change makes GH actions to not run if contracts are not changed

Fixes #144 