### PR TITLE
`fix: remove `_adjustCdp` because it's unnecessary

### DIFF
--- a/packages/contracts/contracts/BorrowerOperations.sol
+++ b/packages/contracts/contracts/BorrowerOperations.sol
@@ -204,7 +204,15 @@ contract BorrowerOperations is
         bytes32 _upperHint,
         bytes32 _lowerHint
     ) external override nonReentrantSelfAndCdpM {
-        _adjustCdpInternal(_cdpId, _collWithdrawal, _EBTCChange, _isDebtIncrease, _upperHint, _lowerHint, 0);
+        _adjustCdpInternal(
+            _cdpId,
+            _collWithdrawal,
+            _EBTCChange,
+            _isDebtIncrease,
+            _upperHint,
+            _lowerHint,
+            0
+        );
     }
 
     /**


### PR DESCRIPTION
Remove `_adjustCDP` you can use `_adjustCDPInternal` and have the ownership check there