### PR TITLE
Fix sweep diamond

### DIFF
--- a/packages/contracts/contracts/Dependencies/SafeERC20.sol
+++ b/packages/contracts/contracts/Dependencies/SafeERC20.sol
@@ -27,7 +27,10 @@ library SafeERC20 {
     }
 
     function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {
-        _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
+        _callOptionalReturn(
+            token,
+            abi.encodeWithSelector(token.transferFrom.selector, from, to, value)
+        );
     }
 
     /**

--- a/packages/contracts/contracts/LeverageMacroBase.sol
+++ b/packages/contracts/contracts/LeverageMacroBase.sol
@@ -11,7 +11,6 @@ import "./Dependencies/ICollateralToken.sol";
 import {ICdpManagerData} from "./Interfaces/ICdpManagerData.sol";
 import "./Dependencies/SafeERC20.sol";
 
-
 interface ICdpCdps {
     function Cdps(bytes32) external view returns (ICdpManagerData.Cdp memory);
 }

--- a/packages/contracts/foundry_test/Proxy.leverage.t.sol
+++ b/packages/contracts/foundry_test/Proxy.leverage.t.sol
@@ -89,10 +89,26 @@ contract ProxyLeverageTest is eBTCBaseInvariants {
             address(fromReference.borrowerOperations()),
             "different BO"
         );
-        assertEq(address(fromFactory.activePool()), address(fromReference.activePool()), "different AP");
-        assertEq(address(fromFactory.cdpManager()), address(fromReference.cdpManager()), "different CDP");
-        assertEq(address(fromFactory.ebtcToken()), address(fromReference.ebtcToken()), "different Token");
-        assertEq(address(fromFactory.sortedCdps()), address(fromReference.sortedCdps()), "different Sorted");
+        assertEq(
+            address(fromFactory.activePool()),
+            address(fromReference.activePool()),
+            "different AP"
+        );
+        assertEq(
+            address(fromFactory.cdpManager()),
+            address(fromReference.cdpManager()),
+            "different CDP"
+        );
+        assertEq(
+            address(fromFactory.ebtcToken()),
+            address(fromReference.ebtcToken()),
+            "different Token"
+        );
+        assertEq(
+            address(fromFactory.sortedCdps()),
+            address(fromReference.sortedCdps()),
+            "different Sorted"
+        );
         assertEq(address(fromFactory.stETH()), address(fromReference.stETH()), "different stETH");
         assertEq(address(fromFactory.owner()), address(fromReference.owner()), "different Owner");
     }


### PR DESCRIPTION
Addresses findings from:
https://github.com/spearbit-audits/review-badgerdao/pull/15

- Adds safeTransfer
- Fixes a test
- Adds sweep to owner for stuck tokens
- Fixes the return value check on excessively safe call to 0

