### PR TITLE
Feat/fl fee fix

### DIFF
--- a/packages/contracts/contracts/Dependencies/ERC3156FlashLender.sol
+++ b/packages/contracts/contracts/Dependencies/ERC3156FlashLender.sol
@@ -12,6 +12,6 @@ abstract contract ERC3156FlashLender is IERC3156FlashLender {
     bytes32 public constant FLASH_SUCCESS_VALUE = keccak256("ERC3156FlashBorrower.onFlashLoan");
 
     // Functions to modify these variables must be included in impelemnting contracts if desired
-    uint16 public feeBps = 50; // 50 BP
+    uint16 public feeBps = 3; // may be subject to future adjustments through protocol governance
     bool public flashLoansPaused;
 }


### PR DESCRIPTION
According to purple paper:

```
Users who wish to take out a flash loan will be required to pay a fee of 0.03% on the borrowed
amount. This fee may be subject to future adjustments through protocol governance
```