### PR TITLE
fix: reset approval function

### DIFF
--- a/packages/contracts/contracts/LeverageMacroReference.sol
+++ b/packages/contracts/contracts/LeverageMacroReference.sol
@@ -44,4 +44,14 @@ contract LeverageMacroReference is LeverageMacroBase {
     function owner() public override returns (address) {
         return theOwner;
     }
+
+    /// @notice use this if you broke the approvals
+    /// @dev diamond wallets can re-approve separately
+    function resetApprovals() external {
+        _assertOwner();
+
+        ebtcToken.approve(address(borrowerOperations), type(uint256).max);
+        stETH.approve(address(borrowerOperations), type(uint256).max);
+        stETH.approve(address(activePool), type(uint256).max);
+    }
 }


### PR DESCRIPTION
Adds `resetApprovals` to the `LeverageMacroReference`

See: https://github.com/cantinasec/review-badgerdao/issues/25