### PR TITLE
feat: GitHub action to run fuzz jobs on contract changes

### DIFF
--- a/.github/workflows/fuzz-tests.yml
+++ b/.github/workflows/fuzz-tests.yml
@@ -1,0 +1,21 @@
+name: Fuzz tests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - packages/contracts/contracts/**
+
+
+jobs:
+  fuzz-tests:
+    name: Run fuzz tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create job 
+        run: |
+          curl -XPOST -H 'Content-Type: application/json'  \
+          -H 'x-api-key: ${{ secrets.FUZZY_FYI_API_KEY }}' \
+          https://app.fuzzy.fyi/api/job --data             \
+          '{"templateId":"76285270-e5f3-47ee-9435-945e6510baf5","ref":"${{ github.head_ref || github.ref_name }}","pullRequestNumber":"${{ github.event.number }}"}'


### PR DESCRIPTION
This GitHub action will create a newjob on fuzzy.fyi whenever a contract changes.
By default, it will reuse the corpus from previous runs (since it has a hardcoded `templateId`).
A bot will comment on the pull request (if there's one associated) whenever the job starts/finishes.
The API key needs to be added as a secret variable.