### PR TITLE
RM "Pause" (aka Grace Period) Cleanup

### DIFF
--- a/packages/contracts/contracts/BorrowerOperations.sol
+++ b/packages/contracts/contracts/BorrowerOperations.sol
@@ -399,10 +399,10 @@ contract BorrowerOperations is
             // We check with newTCR
             if (newTCR < CCR) {
                 // Notify RM
-                cdpManager.notifyBeginRM(newTCR);
+                cdpManager.notifyStartGracePeriod(newTCR);
             } else {
                 // Notify Back to Normal Mode
-                cdpManager.notifyEndRM(newTCR);
+                cdpManager.notifyEndGracePeriod(newTCR);
             }
         } else {
             _requireICRisAboveMCR(vars.ICR);
@@ -411,7 +411,7 @@ contract BorrowerOperations is
             // == Grace Period == //
             // We are not in RM, no edge case, we always stay above RM
             // Always Notify Back to Normal Mode
-            cdpManager.notifyEndRM(newTCR);
+            cdpManager.notifyEndGracePeriod(newTCR);
         }
 
         // Set the cdp struct's properties
@@ -476,7 +476,7 @@ contract BorrowerOperations is
 
         // == Grace Period == //
         // By definition we are not in RM, notify CDPManager to ensure "Glass is on"
-        cdpManager.notifyEndRM(newTCR);
+        cdpManager.notifyEndGracePeriod(newTCR);
 
         cdpManager.removeStake(_cdpId);
 
@@ -658,10 +658,10 @@ contract BorrowerOperations is
             // We check with newTCR
             if (_vars.newTCR < CCR) {
                 // Notify RM
-                cdpManager.notifyBeginRM(_vars.newTCR);
+                cdpManager.notifyStartGracePeriod(_vars.newTCR);
             } else {
                 // Notify Back to Normal Mode
-                cdpManager.notifyEndRM(_vars.newTCR);
+                cdpManager.notifyEndGracePeriod(_vars.newTCR);
             }
         } else {
             // if Normal Mode
@@ -671,7 +671,7 @@ contract BorrowerOperations is
             // == Grace Period == //
             // We are not in RM, no edge case, we always stay above RM
             // Always Notify Back to Normal Mode
-            cdpManager.notifyEndRM(_vars.newTCR);
+            cdpManager.notifyEndGracePeriod(_vars.newTCR);
         }
     }
 

--- a/packages/contracts/contracts/CdpManager.sol
+++ b/packages/contracts/contracts/CdpManager.sol
@@ -353,7 +353,7 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
         _requireValidMaxFeePercentage(_maxFeePercentage);
         _requireAfterBootstrapPeriod();
 
-        _applyPendingGlobalState(); // Apply state, we will checkLiquidateCoolDownAndReset at end of function
+        _applyPendingGlobalState(); // Apply state, we will syncGracePeriod at end of function
 
         totals.price = priceFeed.fetchPrice();
         {
@@ -477,7 +477,7 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
 
         totals.ETHToSendToRedeemer = totals.totalETHDrawn - totals.ETHFee;
 
-        _syncRecoveryModeGracePeriod(
+        _syncGracePeriodForGivenValues(
             totals.totalCollSharesAtStart - totals.totalETHDrawn - totals.totalCollSharesSurplus,
             totals.totalEBTCSupplyAtStart - totals.totalEBTCToRedeem,
             totals.price

--- a/packages/contracts/contracts/Interfaces/ICdpManagerData.sol
+++ b/packages/contracts/contracts/Interfaces/ICdpManagerData.sol
@@ -6,11 +6,11 @@ import "./ICollSurplusPool.sol";
 import "./IEBTCToken.sol";
 import "./ISortedCdps.sol";
 import "./IActivePool.sol";
-import "./IRmLiquidationsChecker.sol";
+import "./IRecoveryModeGracePeriod.sol";
 import "../Dependencies/ICollateralTokenOracle.sol";
 
 // Common interface for the Cdp Manager.
-interface ICdpManagerData is IRmLiquidationsChecker {
+interface ICdpManagerData is IRecoveryModeGracePeriod {
     // --- Events ---
 
     event LiquidationLibraryAddressChanged(address _liquidationLibraryAddress);

--- a/packages/contracts/contracts/Interfaces/IRecoveryModeGracePeriod.sol
+++ b/packages/contracts/contracts/Interfaces/IRecoveryModeGracePeriod.sol
@@ -2,16 +2,16 @@
 pragma solidity 0.8.17;
 
 // Interface for State Updates that can trigger RM Liquidations
-interface IRmLiquidationsChecker {
+interface IRecoveryModeGracePeriod {
     event TCRNotified(uint TCR); /// NOTE: Mostly for debugging to ensure synch
 
     // NOTE: Ts is implicit in events (it's added by GETH)
     event GracePeriodStart();
     event GracePeriodEnd();
 
-    function checkLiquidateCoolDownAndReset() external;
+    function syncGracePeriod() external;
 
-    function notifyBeginRM(uint256 tcr) external;
+    function notifyStartGracePeriod(uint256 tcr) external;
 
-    function notifyEndRM(uint256 tcr) external;
+    function notifyEndGracePeriod(uint256 tcr) external;
 }

--- a/packages/contracts/contracts/LiquidationLibrary.sol
+++ b/packages/contracts/contracts/LiquidationLibrary.sol
@@ -74,11 +74,12 @@ contract LiquidationLibrary is CdpManagerStorage {
 
             // == Grace Period == //
             require(
-                lastRecoveryModeTimestamp != UNSET_TIMESTAMP_FLAG,
-                "Grace period not started, call `notifyBeginRM`"
+                lastGracePeriodStartTimestamp != UNSET_TIMESTAMP,
+                "Grace period not started, call `notifyStartGracePeriod`"
             );
             require(
-                block.timestamp > lastRecoveryModeTimestamp + waitTimeFromRMTriggerToLiquidations,
+                block.timestamp >
+                    lastGracePeriodStartTimestamp + waitTimeFromRMTriggerToLiquidations,
                 "Grace period yet to finish"
             );
         } // Implicit Else Case, Implies ICR < MRC, meaning the CDP is liquidatable
@@ -531,7 +532,7 @@ contract LiquidationLibrary is CdpManagerStorage {
 
         emit Liquidation(totalDebtToBurn, totalColToSend, totalColReward);
 
-        _syncRecoveryModeGracePeriod(
+        _syncGracePeriodForGivenValues(
             systemInitialCollShares - totalColToSend - totalColSurplus,
             systemInitialDebt - totalDebtToBurn,
             price
@@ -1024,8 +1025,8 @@ contract LiquidationLibrary is CdpManagerStorage {
         // ICR < TCR and we have waited enough
         return
             icr < tcr &&
-            lastRecoveryModeTimestamp != UNSET_TIMESTAMP_FLAG &&
-            block.timestamp > lastRecoveryModeTimestamp + waitTimeFromRMTriggerToLiquidations;
+            lastGracePeriodStartTimestamp != UNSET_TIMESTAMP &&
+            block.timestamp > lastGracePeriodStartTimestamp + waitTimeFromRMTriggerToLiquidations;
     }
 
     function _canLiquidateInCurrentMode(

--- a/packages/contracts/foundry_test/BaseFixture.sol
+++ b/packages/contracts/foundry_test/BaseFixture.sol
@@ -504,7 +504,7 @@ contract eBTCBaseFixture is Test, BytecodeReader, LogUtils {
 
     // Grace Period, check never reverts so it's safe to use
     function _waitUntilRMColldown() internal {
-        cdpManager.checkLiquidateCoolDownAndReset();
+        cdpManager.syncGracePeriod();
         vm.warp(block.timestamp + cdpManager.waitTimeFromRMTriggerToLiquidations() + 1);
     }
 }

--- a/packages/contracts/foundry_test/GracePeriod.Sync.t.sol
+++ b/packages/contracts/foundry_test/GracePeriod.Sync.t.sol
@@ -118,7 +118,7 @@ contract GracePeriodBaseTests is eBTCBaseFixture {
 
         // Trigger Liquidations via Split (so price is constant)
         _triggerRMViaSplit();
-        cdpManager.beginRMLiquidationCooldown();
+        cdpManager.syncGracePeriod();
         vm.warp(block.timestamp + cdpManager.waitTimeFromRMTriggerToLiquidations() + 1);
 
         // Liquidate 4x

--- a/packages/contracts/foundry_test/GracePeriod.t.sol
+++ b/packages/contracts/foundry_test/GracePeriod.t.sol
@@ -200,7 +200,7 @@ contract GracePeriodBaseTests is eBTCBaseFixture {
         // Grace Period not started, expect reverts on liquidations
         _assertSuccessOnAllLiquidationsDegen(cdp);
 
-        cdpManager.beginRMLiquidationCooldown();
+        cdpManager.syncGracePeriod();
         // 15 mins not elapsed, prove these cdps still revert
         _assertSuccessOnAllLiquidationsDegen(cdp);
 
@@ -214,7 +214,7 @@ contract GracePeriodBaseTests is eBTCBaseFixture {
         // Grace Period not started, expect reverts on liquidations
         _assertRevertOnAllLiquidations(cdps);
 
-        cdpManager.beginRMLiquidationCooldown();
+        cdpManager.syncGracePeriod();
         // 15 mins not elapsed, prove these cdps still revert
         _assertRevertOnAllLiquidations(cdps);
 
@@ -347,7 +347,7 @@ contract GracePeriodBaseTests is eBTCBaseFixture {
         assertLt(TCR, 1.25e18, "!RM");
 
         // Set grace period before action which exits RM
-        cdpManager.beginRMLiquidationCooldown();
+        cdpManager.syncGracePeriod();
 
         _assertRevertOnAllLiquidations(cdps);
 
@@ -478,9 +478,9 @@ contract GracePeriodBaseTests is eBTCBaseFixture {
         // Grace period timestamp is now
         uint recoveryModeSetTimestamp = block.timestamp;
         assertEq(
-            cdpManager.lastRecoveryModeTimestamp(),
+            cdpManager.lastGracePeriodStartTimestamp(),
             block.timestamp,
-            "lastRecoveryModeTimestamp set time"
+            "lastGracePeriodStartTimestamp set time"
         );
 
         // Liquidations still revert
@@ -491,9 +491,9 @@ contract GracePeriodBaseTests is eBTCBaseFixture {
 
         // Grace period timestamp hasn't changed
         assertEq(
-            cdpManager.lastRecoveryModeTimestamp(),
+            cdpManager.lastGracePeriodStartTimestamp(),
             recoveryModeSetTimestamp,
-            "lastRecoveryModeTimestamp set time"
+            "lastGracePeriodStartTimestamp set time"
         );
 
         // Liquidations work
@@ -503,9 +503,9 @@ contract GracePeriodBaseTests is eBTCBaseFixture {
     function _postExitRMLiquidationChecks(bytes32[] memory cdps) internal {
         // Grace period timestamp is now
         assertEq(
-            cdpManager.lastRecoveryModeTimestamp(),
-            cdpManager.UNSET_TIMESTAMP_FLAG(),
-            "lastRecoveryModeTimestamp unset"
+            cdpManager.lastGracePeriodStartTimestamp(),
+            cdpManager.UNSET_TIMESTAMP(),
+            "lastGracePeriodStartTimestamp unset"
         );
 
         // Liquidations still revert
@@ -516,9 +516,9 @@ contract GracePeriodBaseTests is eBTCBaseFixture {
 
         // Grace period timestamp hasn't changed
         assertEq(
-            cdpManager.lastRecoveryModeTimestamp(),
-            cdpManager.UNSET_TIMESTAMP_FLAG(),
-            "lastRecoveryModeTimestamp unset"
+            cdpManager.lastGracePeriodStartTimestamp(),
+            cdpManager.UNSET_TIMESTAMP(),
+            "lastGracePeriodStartTimestamp unset"
         );
 
         // Only liquidations valid under normal work

--- a/packages/contracts/foundry_test/SandwhichSniper.t.sol
+++ b/packages/contracts/foundry_test/SandwhichSniper.t.sol
@@ -97,7 +97,7 @@ contract SandWhichSniperTest is eBTCBaseFixture {
         // We can now liquidate victim
         /** SANDWHICH 3 */
         vm.startPrank(users[0]);
-        vm.expectRevert("Grace period not started, call `notifyBeginRM`");
+        vm.expectRevert("Grace period not started, call `notifyStartGracePeriod`");
         cdpManager.liquidate(cdpIdVictim);
         uint256 tcrEnd = cdpManager.getTCR(_newPrice);
         console.log("tcrEnd liquidation", tcrEnd);

--- a/packages/contracts/test/CdpManagerTest.js
+++ b/packages/contracts/test/CdpManagerTest.js
@@ -1116,7 +1116,7 @@ contract('CdpManager', async accounts => {
     await borrowerOperations.addColl(_eCdpId, _eCdpId, _eCdpId, dec(10, 'ether'), { from: E })	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 

--- a/packages/contracts/test/CdpManager_RecoveryModeTest.js
+++ b/packages/contracts/test/CdpManager_RecoveryModeTest.js
@@ -2840,7 +2840,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(ICR_C.gt(mv._MCR) && ICR_C.lt(TCR))	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 
@@ -2914,7 +2914,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(ICR_E.gt(mv._MCR) && ICR_E.lt(TCR))	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 
@@ -2982,7 +2982,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(ICR_E.gt(mv._MCR) && ICR_E.lt(TCR))	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 
@@ -3048,7 +3048,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     const entireSystemDebtBefore = await cdpManager.getEntireSystemDebt()	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 
@@ -3165,7 +3165,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(ICR_C_Before.gt(mv._MCR) && ICR_C_Before.lt(TCR))	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 
@@ -3536,7 +3536,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(ICR_C.gt(mv._MCR) && ICR_C.lt(TCR))	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 
@@ -3588,7 +3588,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(ICR_C.gt(mv._MCR) && ICR_C.lt(TCR))	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 
@@ -3658,7 +3658,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(ICR_E.gt(mv._MCR) && ICR_E.lt(TCR))	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 
@@ -3726,7 +3726,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(ICR_E.gt(mv._MCR) && ICR_E.lt(TCR))	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 
@@ -3792,7 +3792,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     const entireSystemDebtBefore = await cdpManager.getEntireSystemDebt()	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 
@@ -3847,7 +3847,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(ICR_C.gt(mv._MCR) && ICR_C.lt(TCR))	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 
@@ -3919,7 +3919,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(ICR_C_Before.gt(mv._MCR) && ICR_C_Before.lt(TCR))	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
 
@@ -4196,7 +4196,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     // but not E as there are not enough funds in liquidator	  
 	  	  
     // trigger cooldown and pass the liq wait
-    await cdpManager.checkLiquidateCoolDownAndReset();
+    await cdpManager.syncGracePeriod();
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
     

--- a/packages/contracts/test/CdpManager_RecoveryMode_Batch_Liqudation_Test.js
+++ b/packages/contracts/test/CdpManager_RecoveryMode_Batch_Liqudation_Test.js
@@ -77,7 +77,7 @@ contract('CdpManager - in Recovery Mode - back to normal mode in 1 tx', async ac
       await setup()		  
 	  	  
       // trigger cooldown and pass the liq wait
-      await cdpManager.checkLiquidateCoolDownAndReset();
+      await cdpManager.syncGracePeriod();
       await ethers.provider.send("evm_increaseTime", [901]);
       await ethers.provider.send("evm_mine");
 		
@@ -97,7 +97,7 @@ contract('CdpManager - in Recovery Mode - back to normal mode in 1 tx', async ac
       let _carolCdpId = await sortedCdps.cdpOfOwnerByIndex(carol, 0);		  
 	  	  
       // trigger cooldown and pass the liq wait
-      await cdpManager.checkLiquidateCoolDownAndReset();
+      await cdpManager.syncGracePeriod();
       await ethers.provider.send("evm_increaseTime", [901]);
       await ethers.provider.send("evm_mine");
 		
@@ -154,7 +154,7 @@ contract('CdpManager - in Recovery Mode - back to normal mode in 1 tx', async ac
       assert.isTrue(ICR_C.lt(mv._ICR100))		  
 	  	  
       // trigger cooldown and pass the liq wait
-      await cdpManager.checkLiquidateCoolDownAndReset();
+      await cdpManager.syncGracePeriod();
       await ethers.provider.send("evm_increaseTime", [901]);
       await ethers.provider.send("evm_mine");
 
@@ -217,7 +217,7 @@ contract('CdpManager - in Recovery Mode - back to normal mode in 1 tx', async ac
       await setup()		  
 	  	  
       // trigger cooldown and pass the liq wait
-      await cdpManager.checkLiquidateCoolDownAndReset();
+      await cdpManager.syncGracePeriod();
       await ethers.provider.send("evm_increaseTime", [901]);
       await ethers.provider.send("evm_mine");
 		
@@ -235,7 +235,7 @@ contract('CdpManager - in Recovery Mode - back to normal mode in 1 tx', async ac
       let _bobCdpId = await sortedCdps.cdpOfOwnerByIndex(bob, 0);		  
 	  	  
       // trigger cooldown and pass the liq wait
-      await cdpManager.checkLiquidateCoolDownAndReset();
+      await cdpManager.syncGracePeriod();
       await ethers.provider.send("evm_increaseTime", [901]);
       await ethers.provider.send("evm_mine");
 		

--- a/packages/contracts/test/CdpManager_SimpleLiquidation_Test.js
+++ b/packages/contracts/test/CdpManager_SimpleLiquidation_Test.js
@@ -395,7 +395,7 @@ contract('CdpManager - Simple Liquidation with external liquidators', async acco
       assert.isTrue(toBN(prevDebtOfOwner.toString()).gt(toBN(aliceDebt.toString())));	  
 	  	  
       // trigger cooldown and pass the liq wait
-      await cdpManager.checkLiquidateCoolDownAndReset();
+      await cdpManager.syncGracePeriod();
       await ethers.provider.send("evm_increaseTime", [901]);
       await ethers.provider.send("evm_mine");
 	  

--- a/packages/contracts/test/CdpManager_StakingSplitFee_Test.js
+++ b/packages/contracts/test/CdpManager_StakingSplitFee_Test.js
@@ -284,7 +284,7 @@ contract('CdpManager - Simple Liquidation with external liquidators', async acco
       let _collBeforeLiquidator = await collToken.balanceOf(owner);		  
 	  	  
       // trigger cooldown and pass the liq wait
-      await cdpManager.checkLiquidateCoolDownAndReset();
+      await cdpManager.syncGracePeriod();
       await ethers.provider.send("evm_increaseTime", [901]);
       await ethers.provider.send("evm_mine");
 	  


### PR DESCRIPTION
## RM "Pause" (aka Grace Period) Cleanup

This concept is now called the "grace period" and is referred to more specifically as the "recovery mode grace period" in the interface file.

As the grace period concept doesn't otherwise exist with the same name, we shorten to "grace period" in all other references.

BO functions are renamed:
`notifyBeginRM ` -> `notifyEndGracePeriod`
`notifyEndRM ` -> `notifyEndGracePeriod`

Varibles are renamed:
`lastRecoveryModeTimestamp` -> `lastGracePeriodStartTimestamp`
`UNSET_TIMESTAMP_FLAG` -> `UNSET_TIMESTAMP` (found the 'flag' terminology unecessary)

consolidiated `_beginRMLiquidationCooldown` and `_notifyBeginRM` inner functions to `_startGracePeriod`
here is where we emit the event and set the timestamp

I found the two internal functions excessive given the code complexity level and paths and it was a simple refactor.

(In addition, the double-functions led to me missing the TcrNotified() event on my _syncGracePeriod() internal call)

Every way of calling this logic boils down to:
`_startGracePeriod` and `_endGracePeriod`

they just support different ways of getting TCR (of which the components are systemCollShares, systemDebt, price) to optimally support the existing function flows

External functions `beginRMLiquidationCooldown ` and `endRMLiquidationCooldown ` were removed in favor of a single `syncGracePeriod` function

## Next Up: Governance
There will be a way to set the gracePeriod duration, but we will still have the minimum constant that governance can't go shorter than.
Will add variable packing