### PR TITLE
Run the fuzzer with 10k runs when targeting main

### DIFF
--- a/.github/workflows/foundry-test.yml
+++ b/.github/workflows/foundry-test.yml
@@ -44,4 +44,4 @@ jobs:
 
       - name: Foundry Test
         working-directory: ./packages/contracts/
-        run: forge test -vvv
+        run: forge test -vvv ${{ github.base_ref == 'main' && '--fuzz-runs 10000' || '' }}


### PR DESCRIPTION
While refactoring our usage of `vm.assume` to `bound` (https://github.com/Badger-Finance/ebtc/pull/631), I came to the conclusion that our fuzz tests aren't as thorough as they seem...

Our `foundry.toml` is super limiting

```
[fuzz]
max_test_rejects=2147483647
runs=40
```

This means that the fuzzer tests only 40 inputs. That's almost nothing when compared to echidna's 50k for an "initial" run, and 1M for a "good enough" run

This PR sets it to 10k for PRs to main
