### PR TITLE
Add stopOnFail: true to echidna config

### DIFF
--- a/packages/contracts/fuzzTests/echidna_config.yaml
+++ b/packages/contracts/fuzzTests/echidna_config.yaml
@@ -33,6 +33,9 @@ testMaxGas: 1000000000
 # by default, blacklist methods in filterFunctions
 #filterBlacklist: false
 
+#stopOnFail makes echidna terminate as soon as any property fails and has been shrunk
+stopOnFail: true
+
 #coverage controls coverage guided testing
 coverage: true
 


### PR DESCRIPTION
After letting echidna run overnight with 1M runs, some jobs encountered broken invariants, but the ETA is still 4+ days.

In order to optimize this process, I propose setting `stopOnFail: true` so that it immediately exits after the shrinking step finishes