### PR TITLE
synced ICR in redeem and liquidate

### DIFF
--- a/packages/contracts/contracts/CdpManager.sol
+++ b/packages/contracts/contracts/CdpManager.sol
@@ -282,13 +282,13 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
         if (
             _firstRedemptionHint == sortedCdps.nonExistId() ||
             !sortedCdps.contains(_firstRedemptionHint) ||
-            getICR(_firstRedemptionHint, _price) < MCR
+            getSyncedICR(_firstRedemptionHint, _price) < MCR
         ) {
             return false;
         }
 
         bytes32 nextCdp = sortedCdps.getNext(_firstRedemptionHint);
-        return nextCdp == sortedCdps.nonExistId() || getICR(nextCdp, _price) < MCR;
+        return nextCdp == sortedCdps.nonExistId() || getSyncedICR(nextCdp, _price) < MCR;
     }
 
     /** 
@@ -373,7 +373,7 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
             _cId = sortedCdps.getLast();
             currentBorrower = sortedCdps.getOwnerAddress(_cId);
             // Find the first cdp with ICR >= MCR
-            while (currentBorrower != address(0) && getICR(_cId, totals.price) < MCR) {
+            while (currentBorrower != address(0) && getSyncedICR(_cId, totals.price) < MCR) {
                 _cId = sortedCdps.getPrev(_cId);
                 currentBorrower = sortedCdps.getOwnerAddress(_cId);
             }

--- a/packages/contracts/contracts/LiquidationLibrary.sol
+++ b/packages/contracts/contracts/LiquidationLibrary.sol
@@ -61,7 +61,7 @@ contract LiquidationLibrary is CdpManagerStorage {
         uint256 _price = priceFeed.fetchPrice();
 
         // prepare local variables
-        uint256 _ICR = getICR(_cdpId, _price);
+        uint256 _ICR = getICR(_cdpId, _price); // @audit syncAccounting already called, guarenteed to be synced
         (uint256 _TCR, uint256 systemColl, uint256 systemDebt) = _getTCRWithSystemDebtAndCollShares(
             _price
         );
@@ -714,7 +714,7 @@ contract LiquidationLibrary is CdpManagerStorage {
             vars.cdpId = _cdpArray[vars.i];
             // only for active cdps
             if (vars.cdpId != bytes32(0) && Cdps[vars.cdpId].status == Status.active) {
-                vars.ICR = getICR(vars.cdpId, _price);
+                vars.ICR = getSyncedICR(vars.cdpId, _price);
 
                 if (
                     !vars.backToNormalMode &&
@@ -819,7 +819,7 @@ contract LiquidationLibrary is CdpManagerStorage {
             vars.cdpId = _cdpArray[vars.i];
             // only for active cdps
             if (vars.cdpId != bytes32(0) && Cdps[vars.cdpId].status == Status.active) {
-                vars.ICR = getICR(vars.cdpId, _price);
+                vars.ICR = getSyncedICR(vars.cdpId, _price);
 
                 if (vars.ICR < MCR) {
                     _syncAccounting(vars.cdpId);

--- a/packages/contracts/foundry_test/MinCdpSizeOpening.t.sol
+++ b/packages/contracts/foundry_test/MinCdpSizeOpening.t.sol
@@ -1,0 +1,41 @@
+pragma solidity 0.8.17;
+
+import {console2 as console} from "forge-std/console2.sol";
+
+import {eBTCBaseFixture} from "./BaseFixture.sol";
+
+contract MinCdpSizeOpeningPOCTest is eBTCBaseFixture {
+    address payable[] users;
+    address private splitFeeRecipient;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Tests
+    ////////////////////////////////////////////////////////////////////////////
+
+    function setUp() public override {
+        super.setUp();
+
+        connectCoreContracts();
+        connectLQTYContractsToCore();
+
+        users = _utils.createUsers(3);
+
+        splitFeeRecipient = address(feeRecipient);
+
+        collateral.setEthPerShare(0.9e18);
+    }
+
+    /**
+        Proof that Split goes down after claiming
+     */
+    function test_OpenMinCdpSize_NormalMode() public {
+        uint256 debtAmt = 1e20; // TODO: Consider fuzz
+
+        uint256 _curPrice = priceFeedMock.getPrice();
+        uint256 coll1 = _utils.calculateCollAmount(debtAmt, _curPrice, 126e16);
+
+        bytes32 cdpId1 = _openTestCDP(users[0], coll1, debtAmt);
+    }
+
+    function test_OpenMinCdpSize_RecoveryMode() public {}
+}


### PR DESCRIPTION
all getICR() operations that happen _before_ CDP accounting accrual become getSyncedICR()

note: any getICR() / getTCR() operation should have a note saying it's ok because things are already synced.