### PR TITLE
remove stake conslidation

### DIFF
--- a/packages/contracts/contracts/BorrowerOperations.sol
+++ b/packages/contracts/contracts/BorrowerOperations.sol
@@ -522,8 +522,6 @@ contract BorrowerOperations is
         // By definition we are not in RM, notify CDPManager to ensure "Glass is on"
         cdpManager.notifyEndGracePeriod(newTCR);
 
-        cdpManager.removeStake(_cdpId);
-
         // We already verified msg.sender is the borrower
         cdpManager.closeCdp(_cdpId, msg.sender, debt, coll);
 

--- a/packages/contracts/contracts/CdpManager.sol
+++ b/packages/contracts/contracts/CdpManager.sol
@@ -252,7 +252,6 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
         uint256 _liquidatorRewardShares,
         address _borrower
     ) internal {
-        _removeStake(_cdpId);
         _closeCdpWithoutRemovingSortedCdps(_cdpId, Status.closedByRedemption);
 
         // Update Active Pool EBTC, and send ETH to account
@@ -516,11 +515,6 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
     function syncAccounting(bytes32 _cdpId) external override {
         // _requireCallerIsBorrowerOperations(); /// @audit Please check this and let us know if opening this creates issues
         return _syncAccounting(_cdpId);
-    }
-
-    function removeStake(bytes32 _cdpId) external override {
-        _requireCallerIsBorrowerOperations();
-        return _removeStake(_cdpId);
     }
 
     // get totalStakes after split fee taken removed

--- a/packages/contracts/contracts/CdpManagerStorage.sol
+++ b/packages/contracts/contracts/CdpManagerStorage.sol
@@ -263,6 +263,8 @@ contract CdpManagerStorage is EbtcBase, ReentrancyGuard, ICdpManagerData, AuthNo
         uint256 cdpIdsArrayLength = CdpIds.length;
         _requireMoreThanOneCdpInSystem(cdpIdsArrayLength);
 
+        _removeStake(_cdpId);
+
         Cdps[_cdpId].status = closedStatus;
         Cdps[_cdpId].coll = 0;
         Cdps[_cdpId].debt = 0;

--- a/packages/contracts/contracts/Interfaces/ICdpManager.sol
+++ b/packages/contracts/contracts/Interfaces/ICdpManager.sol
@@ -41,8 +41,6 @@ interface ICdpManager is IEbtcBase, ICdpManagerData {
 
     function closeCdp(bytes32 _cdpId, address _borrower, uint256 _debt, uint256 _coll) external;
 
-    function removeStake(bytes32 _cdpId) external;
-
     function getRedemptionRate() external view returns (uint256);
 
     function getRedemptionRateWithDecay() external view returns (uint256);

--- a/packages/contracts/test/AccessControlTest.js
+++ b/packages/contracts/test/AccessControlTest.js
@@ -68,18 +68,6 @@ contract('Access Control: Liquity functions with the caller restricted to Liquit
       }
     })
 
-    // removeStake
-    it("removeStake(): reverts when called by an account that is not BorrowerOperations", async () => {
-      // Attempt call from alice
-      try {
-        const txAlice = await cdpManager.removeStake(bob, { from: alice })
-        
-      } catch (err) {
-        assert.include(err.message, "revert")
-        // assert.include(err.message, "Caller is not the BorrowerOperations contract")
-      }
-    })
-
     // updateStakeAndTotalStakes
     it("updateStakeAndTotalStakes(): reverts when called by an account that is not BorrowerOperations", async () => {
       // Attempt call from alice


### PR DESCRIPTION
`_removeStake(_cdpId)` previous happened independently from the 3 paths to closing:
* closed by borrower (or positionManager)
* closed by liquidation
* closed by redemption

In each case it happened before the actual 'closure' sequence

now it is consolidated to be the same on each path.