### PR TITLE
Fix: Readme + Unused variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ We should gracefully handle the case of no fallback oracle, as well as switching
 
 ### If Chainlink dependencies burn all gas, or the contract is destructed, then the Price Feed will revert
 
+### If Chainlink performs an upgrade, due to how PhaseId and RoundId are calculated the price will be stale
+
+This is because there will not be a valid price at roundId - 1
+
+The Oracle will resume working as intended once the CL Feed reports 2 prices from the same aggregator (see Spearibit / Cantina Reports for more details)
+
 ### We understand some rounding errors can happen
 Badger will:
 - Donate up to 2 stETH of collateral to the system contracts as a way to prevent any shortfall due to rounding (avoids off by one errors)

--- a/packages/contracts/contracts/CdpManagerStorage.sol
+++ b/packages/contracts/contracts/CdpManagerStorage.sol
@@ -200,8 +200,6 @@ contract CdpManagerStorage is EbtcBase, ReentrancyGuard, ICdpManagerData, AuthNo
     uint256 public override systemStEthFeePerUnitIndexError;
     /* Individual CDP Fee accumulator tracker, used to calculate fee split distribution */
     mapping(bytes32 => uint256) public cdpStEthFeePerUnitIndex;
-    /* Update timestamp for global index */
-    uint256 lastIndexTimestamp;
 
     // Array of all active cdp Ids - used to to compute an approximate hint off-chain, for the sorted list insertion
     bytes32[] public CdpIds;
@@ -541,7 +539,6 @@ contract CdpManagerStorage is EbtcBase, ReentrancyGuard, ICdpManagerData, AuthNo
     function _syncStEthIndex(uint256 _oldIndex, uint256 _newIndex) internal {
         if (_newIndex != _oldIndex) {
             stEthIndex = _newIndex;
-            lastIndexTimestamp = block.timestamp;
             emit StEthIndexUpdated(_oldIndex, _newIndex, block.timestamp);
         }
     }


### PR DESCRIPTION
- CL known issue about prev round
- lastIndexTimestamp is unused

NOTE: `deploymentStartTime` is also basically unused could scrap as well