### PR TITLE
C4 310 & 256 Mitigation

### DIFF
--- a/packages/contracts/contracts/PriceFeed.sol
+++ b/packages/contracts/contracts/PriceFeed.sol
@@ -188,18 +188,6 @@ contract PriceFeed is BaseMath, IPriceFeed, AuthNoOwner {
 
         // --- CASE 2: The system fetched last price from Fallback ---
         if (status == Status.usingFallbackChainlinkUntrusted) {
-            // If both Fallback and Chainlink are live, unbroken, and reporting similar prices, switch back to Chainlink
-            if (
-                _bothOraclesLiveAndUnbrokenAndSimilarPrice(
-                    chainlinkResponse,
-                    prevChainlinkResponse,
-                    fallbackResponse
-                )
-            ) {
-                _changeStatus(Status.chainlinkWorking);
-                return _storeChainlinkPrice(chainlinkResponse.answer);
-            }
-
             if (_fallbackIsBroken(fallbackResponse)) {
                 _changeStatus(Status.bothOraclesUntrusted);
                 return lastGoodPrice;
@@ -211,6 +199,18 @@ contract PriceFeed is BaseMath, IPriceFeed, AuthNoOwner {
              */
             if (_fallbackIsFrozen(fallbackResponse)) {
                 return lastGoodPrice;
+            }
+
+            // If both Fallback and Chainlink are live, unbroken, and reporting similar prices, switch back to Chainlink
+            if (
+                _bothOraclesLiveAndUnbrokenAndSimilarPrice(
+                    chainlinkResponse,
+                    prevChainlinkResponse,
+                    fallbackResponse
+                )
+            ) {
+                _changeStatus(Status.chainlinkWorking);
+                return _storeChainlinkPrice(chainlinkResponse.answer);
             }
 
             // Otherwise, use Fallback price
@@ -226,10 +226,13 @@ contract PriceFeed is BaseMath, IPriceFeed, AuthNoOwner {
                 // If CL has resumed working
                 if (
                     !_chainlinkIsBroken(chainlinkResponse, prevChainlinkResponse) &&
-                    !_chainlinkIsFrozen(chainlinkResponse)
+                    !_chainlinkIsFrozen(chainlinkResponse) &&
+                    !_chainlinkPriceChangeAboveMax(chainlinkResponse, prevChainlinkResponse)
                 ) {
                     _changeStatus(Status.usingChainlinkFallbackUntrusted);
                     return _storeChainlinkPrice(chainlinkResponse.answer);
+                } else {
+                    return lastGoodPrice;
                 }
             }
 
@@ -324,6 +327,13 @@ contract PriceFeed is BaseMath, IPriceFeed, AuthNoOwner {
                 return lastGoodPrice;
             }
 
+            // If Chainlink is live but deviated >50% from it's previous price and Fallback is still untrusted, switch
+            // to bothOraclesUntrusted and return last good price
+            if (_chainlinkPriceChangeAboveMax(chainlinkResponse, prevChainlinkResponse)) {
+                _changeStatus(Status.bothOraclesUntrusted);
+                return lastGoodPrice;
+            }
+
             // If Chainlink and Fallback are both live, unbroken and similar price, switch back to chainlinkWorking and return Chainlink price
             if (
                 _bothOraclesLiveAndUnbrokenAndSimilarPrice(
@@ -332,15 +342,10 @@ contract PriceFeed is BaseMath, IPriceFeed, AuthNoOwner {
                     fallbackResponse
                 )
             ) {
-                _changeStatus(Status.chainlinkWorking);
+                if (address(fallbackCaller) != address(0)) {
+                    _changeStatus(Status.chainlinkWorking);
+                }
                 return _storeChainlinkPrice(chainlinkResponse.answer);
-            }
-
-            // If Chainlink is live but deviated >50% from it's previous price and Fallback is still untrusted, switch
-            // to bothOraclesUntrusted and return last good price
-            if (_chainlinkPriceChangeAboveMax(chainlinkResponse, prevChainlinkResponse)) {
-                _changeStatus(Status.bothOraclesUntrusted);
-                return lastGoodPrice;
             }
 
             // Otherwise if Chainlink is live and deviated <50% from it's previous price and Fallback is still untrusted,
@@ -508,8 +513,8 @@ contract PriceFeed is BaseMath, IPriceFeed, AuthNoOwner {
     ) internal view returns (bool) {
         // Return false if either oracle is broken or frozen
         if (
-            _fallbackIsBroken(_fallbackResponse) ||
-            _fallbackIsFrozen(_fallbackResponse) ||
+            (address(fallbackCaller) != address(0) &&
+                (_fallbackIsBroken(_fallbackResponse) || _fallbackIsFrozen(_fallbackResponse))) ||
             _chainlinkIsBroken(_chainlinkResponse, _prevChainlinkResponse) ||
             _chainlinkIsFrozen(_chainlinkResponse)
         ) {
@@ -527,7 +532,10 @@ contract PriceFeed is BaseMath, IPriceFeed, AuthNoOwner {
     function _bothOraclesSimilarPrice(
         ChainlinkResponse memory _chainlinkResponse,
         FallbackResponse memory _fallbackResponse
-    ) internal pure returns (bool) {
+    ) internal view returns (bool) {
+        if (address(fallbackCaller) == address(0)) {
+            return true;
+        }
         // Get the relative price difference between the oracles. Use the lower price as the denominator, i.e. the reference for the calculation.
         uint256 minPrice = EbtcMath._min(_fallbackResponse.answer, _chainlinkResponse.answer);
         if (minPrice == 0) return false;

--- a/packages/contracts/contracts/TestContracts/MockFallbackCaller.sol
+++ b/packages/contracts/contracts/TestContracts/MockFallbackCaller.sol
@@ -9,9 +9,14 @@ contract MockFallbackCaller is IFallbackCaller {
     uint256 public _timestampRetrieved;
     uint256 public _fallbackTimeout;
     bool public _success;
+    uint256 public _initAnswer;
 
     bool public getFallbackResponseRevert;
     bool public fallbackTimeoutRevert;
+
+    constructor(uint256 answer) {
+        _initAnswer = answer;
+    }
 
     function setGetFallbackResponseRevert() external {
         getFallbackResponseRevert = !getFallbackResponseRevert;

--- a/packages/contracts/contracts/TestContracts/PriceFeedTester.sol
+++ b/packages/contracts/contracts/TestContracts/PriceFeedTester.sol
@@ -42,7 +42,7 @@ contract PriceFeedTester is PriceFeed {
     function bothOraclesSimilarPrice(
         ChainlinkResponse memory _chainlinkResponse,
         FallbackResponse memory _fallbackResponse
-    ) public pure returns (bool) {
+    ) public view returns (bool) {
         return _bothOraclesSimilarPrice(_chainlinkResponse, _fallbackResponse);
     }
 

--- a/packages/contracts/contracts/TestContracts/invariants/PropertiesDescriptions.sol
+++ b/packages/contracts/contracts/TestContracts/invariants/PropertiesDescriptions.sol
@@ -142,4 +142,5 @@ abstract contract PropertiesDescriptions {
     string constant PF_05 =
         "PF-05: The price feed should never use the fallback if chainlink is Working";
     string constant PF_06 = "PF-06: The system never tries to use the fallback if it is not set";
+    string constant PF_07 = "PF-07: The price feed should never return different prices when called multiple times in a single tx";
 }

--- a/packages/contracts/contracts/TestContracts/invariants/PropertiesDescriptions.sol
+++ b/packages/contracts/contracts/TestContracts/invariants/PropertiesDescriptions.sol
@@ -142,5 +142,6 @@ abstract contract PropertiesDescriptions {
     string constant PF_05 =
         "PF-05: The price feed should never use the fallback if chainlink is Working";
     string constant PF_06 = "PF-06: The system never tries to use the fallback if it is not set";
-    string constant PF_07 = "PF-07: The price feed should never return different prices when called multiple times in a single tx";
+    string constant PF_07 =
+        "PF-07: The price feed should never return different prices when called multiple times in a single tx";
 }

--- a/packages/contracts/contracts/TestContracts/invariants/echidna/EchidnaPriceFeedTester.sol
+++ b/packages/contracts/contracts/TestContracts/invariants/echidna/EchidnaPriceFeedTester.sol
@@ -184,7 +184,19 @@ contract EchidnaPriceFeedTester is PropertiesConstants, PropertiesAsserts, Prope
         aggregator.setPrevUpdateTime(prevUpdateTime);
     }
 
+    function fetchPriceBatch() public log {
+        uint256 price = _fetchPrice();
+        for (uint256 i; i < 2; i++) {
+            uint256 newPrice = _fetchPrice();
+            assertWithMsg(price == newPrice, PF_07);
+        }
+    }
+
     function fetchPrice() public log {
+        _fetchPrice();
+    }
+
+    function _fetchPrice() private returns (uint256) {
         IPriceFeed.Status statusBefore = priceFeed.status();
         uint256 fallbackResponse;
 
@@ -218,6 +230,8 @@ contract EchidnaPriceFeedTester is PropertiesConstants, PropertiesAsserts, Prope
                 // TODO: this is hard to test, as we may have false positives due to the random nature of the tests
                 // assertWithMsg(_hasNotDeadlocked(), PF_03);
             }
+
+            return price;
         } catch {
             assertWithMsg(false, PF_01);
         }

--- a/packages/contracts/foundry_test/PriceFeed.stateTransitions.t.sol
+++ b/packages/contracts/foundry_test/PriceFeed.stateTransitions.t.sol
@@ -318,14 +318,13 @@ contract PriceFeedStateTransitionTest is eBTCBaseInvariants {
         // --- CASE 3: Both oracles were untrusted at the last price fetch ---
         else if (currentStatus == IPriceFeed.Status.bothOraclesUntrusted) {
             // Fallback isn't working so we can't compare the prices. Go ahead and trust CL for now that it's reporting and is the only valid oracle
-            if (
-                address(priceFeedTester.fallbackCaller()) == address(0) &&
-                !chainlinkFrozen &&
-                !chainlinkBroken &&
-                !chainlinkPriceChangeAboveMax
-            ) {
-                // Chainlink is now working, return to it, but note that fallback is still untrusted
-                newStatus = IPriceFeed.Status.usingChainlinkFallbackUntrusted;
+            if (address(priceFeedTester.fallbackCaller()) == address(0)) {
+                if (!chainlinkFrozen && !chainlinkBroken && !chainlinkPriceChangeAboveMax) {
+                    // Chainlink is now working, return to it, but note that fallback is still untrusted
+                    newStatus = IPriceFeed.Status.usingChainlinkFallbackUntrusted;
+                } else {
+                    newStatus = currentStatus;
+                }
             } else if (bothOraclesAliveAndUnrokenSimilarPrice) {
                 // CL and FB working, reporting similar prices (<5% difference)
                 // Chainlink is now working, return to it


### PR DESCRIPTION
address https://github.com/code-423n4/2023-10-badger-findings/issues/310 & https://github.com/code-423n4/2023-10-badger-findings/issues/256 by adding extra checks around `PriceFeed` state machine if fallback oracle is empty (not set) and CL reports 50% deviation between rounds

- Additional checks in `_bothOraclesLiveAndUnbrokenAndSimilarPrice()` & `_bothOraclesSimilarPrice()` to distinguish the situations when fallback is set (broken/frozen) AND when fallback is not set at all
- Ensure only change to `usingChainlinkFallbackUntrusted` if CL reports pass the max deviation check in status `bothOraclesUntrusted` ( `case 3` in the `PriceFeed` state machine)
- Ensure correct state and price returned if CL reports doesn't pass the max deviation check in status `usingFallbackChainlinkFrozen` ( `case 4` in the `PriceFeed` state machine)
- Ensue above similarity comparison (`_bothOraclesLiveAndUnbrokenAndSimilarPrice()` or `_bothOraclesSimilarPrice()`) between primary & fallback oracle happens **ONLY AFTER** other single-source checks have passed (bad/frozen/max-deviation) in each status