### PR TITLE
Add accounting data for collSurplus allocations

### DIFF
--- a/packages/contracts/contracts/CdpManager.sol
+++ b/packages/contracts/contracts/CdpManager.sol
@@ -254,7 +254,12 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
         activePool.decreaseSystemDebt(_EBTC);
 
         // Register stETH surplus from upcoming transfers of stETH collateral and liquidator reward shares
-        collSurplusPool.increaseSurplusCollShares(_borrower, _collSurplus + _liquidatorRewardShares);
+        collSurplusPool.increaseSurplusCollShares(
+            _cdpId,
+            _borrower,
+            _collSurplus,
+            _liquidatorRewardShares
+        );
 
         // CEI: send stETH coll and liquidator reward shares from Active Pool to CollSurplus Pool
         activePool.transferSystemCollSharesAndLiquidatorReward(

--- a/packages/contracts/contracts/CollSurplusPool.sol
+++ b/packages/contracts/contracts/CollSurplusPool.sol
@@ -70,17 +70,33 @@ contract CollSurplusPool is ICollSurplusPool, ReentrancyGuard, AuthNoOwner {
 
     // --- Pool functionality ---
 
-    /// @notice Increase collateral surplus balance for owner _account by _amount
-    /// @param _account The owner address whose surplus balance is increased
-    /// @param _amount The surplus increase value
-    /// @dev only CdpManager is allowed to call this function
-    function increaseSurplusCollShares(address _account, uint256 _amount) external override {
+    /// @notice Increases the claimable surplus collateral shares for the specified account.
+    /// @notice Internal permissioned system function, can track amounts added from collateral shares and liquidator reward shares separately for accounting purposes.
+    /// @dev Only the CdpManager contract can call this function.
+    /// @param _cdpId CdpId surplus collateral shares come from, for accounting purposes.
+    /// @param _account The account to increase collateral surplus balance for.
+    /// @param _collateralShares The number of collateral shares to be added to the owner's surplus balance, from Cdp collateral shares.
+    /// @param _liquidatorRewardShares The number of collateral shares to be added to the owner's surplus balance, from liquidator reward shares.
+    function increaseSurplusCollShares(
+        bytes32 _cdpId,
+        address _account,
+        uint256 _collateralShares,
+        uint256 _liquidatorRewardShares
+    ) external override {
         _requireCallerIsCdpManager();
 
-        uint256 newAmount = balances[_account] + _amount;
-        balances[_account] = newAmount;
+        uint256 _totalClaimableSurplusCollShares = balances[_account] +
+            _collateralShares +
+            _liquidatorRewardShares;
+        balances[_account] = _totalClaimableSurplusCollShares;
 
-        emit SurplusCollSharesUpdated(_account, newAmount);
+        emit SurplusCollSharesAdded(
+            _cdpId,
+            _account,
+            _totalClaimableSurplusCollShares,
+            _collateralShares,
+            _liquidatorRewardShares
+        );
     }
 
     /// @notice Allow owner to claim all its surplus recorded in this pool
@@ -92,7 +108,6 @@ contract CollSurplusPool is ICollSurplusPool, ReentrancyGuard, AuthNoOwner {
         require(claimableColl > 0, "CollSurplusPool: No collateral available to claim");
 
         balances[_account] = 0;
-        emit SurplusCollSharesUpdated(_account, 0);
 
         uint256 cachedTotalSurplusCollShares = totalSurplusCollShares;
 
@@ -101,6 +116,7 @@ contract CollSurplusPool is ICollSurplusPool, ReentrancyGuard, AuthNoOwner {
         unchecked {
             totalSurplusCollShares = cachedTotalSurplusCollShares - claimableColl;
         }
+        emit SurplusCollSharesClaimed(_account, claimableColl);
         emit CollSharesTransferred(_account, claimableColl);
 
         // NOTE: No need for safe transfer if the collateral asset is standard. Make sure this is the case!

--- a/packages/contracts/contracts/CollSurplusPool.sol
+++ b/packages/contracts/contracts/CollSurplusPool.sol
@@ -116,7 +116,6 @@ contract CollSurplusPool is ICollSurplusPool, ReentrancyGuard, AuthNoOwner {
         unchecked {
             totalSurplusCollShares = cachedTotalSurplusCollShares - claimableColl;
         }
-        emit SurplusCollSharesClaimed(_account, claimableColl);
         emit CollSharesTransferred(_account, claimableColl);
 
         // NOTE: No need for safe transfer if the collateral asset is standard. Make sure this is the case!

--- a/packages/contracts/contracts/Dependencies/RolesAuthority.sol
+++ b/packages/contracts/contracts/Dependencies/RolesAuthority.sol
@@ -56,7 +56,7 @@ contract RolesAuthority is IRolesAuthority, Auth, Authority {
     //////////////////////////////////////////////////////////////*/
 
     /**
-        @notice A user can call a given function signature on a given target address if:
+        @notice A user can c    all a given function signature on a given target address if:
             - The capability has not been burned
             - That capability is public, or the user has a role that has been granted the capability to call the function
      */

--- a/packages/contracts/contracts/Dependencies/RolesAuthority.sol
+++ b/packages/contracts/contracts/Dependencies/RolesAuthority.sol
@@ -56,7 +56,7 @@ contract RolesAuthority is IRolesAuthority, Auth, Authority {
     //////////////////////////////////////////////////////////////*/
 
     /**
-        @notice A user can c    all a given function signature on a given target address if:
+        @notice A user can call a given function signature on a given target address if:
             - The capability has not been burned
             - That capability is public, or the user has a role that has been granted the capability to call the function
      */

--- a/packages/contracts/contracts/Interfaces/ICollSurplusPool.sol
+++ b/packages/contracts/contracts/Interfaces/ICollSurplusPool.sol
@@ -5,7 +5,14 @@ pragma solidity 0.8.17;
 interface ICollSurplusPool {
     // --- Events ---
 
-    event SurplusCollSharesUpdated(address indexed _account, uint256 _newBalance);
+    event SurplusCollSharesClaimed(address indexed _account, uint256 _collShares);
+    event SurplusCollSharesAdded(
+        bytes32 indexed _cdpId,
+        address indexed _account,
+        uint256 _claimableSurplusCollShares,
+        uint256 _surplusCollSharesAddedFromCollateral,
+        uint256 _surplusCollSharesAddedFromLiquidatorReward
+    );
     event CollSharesTransferred(address indexed _to, uint256 _amount);
 
     event SweepTokenSuccess(address indexed _token, uint256 _amount, address indexed _recipient);
@@ -16,7 +23,12 @@ interface ICollSurplusPool {
 
     function getSurplusCollShares(address _account) external view returns (uint256);
 
-    function increaseSurplusCollShares(address _account, uint256 _amount) external;
+    function increaseSurplusCollShares(
+        bytes32 _cdpId,
+        address _account,
+        uint256 _collateralShares,
+        uint256 _liquidatorRewardShares
+    ) external;
 
     function claimSurplusCollShares(address _account) external;
 

--- a/packages/contracts/contracts/Interfaces/ICollSurplusPool.sol
+++ b/packages/contracts/contracts/Interfaces/ICollSurplusPool.sol
@@ -5,7 +5,6 @@ pragma solidity 0.8.17;
 interface ICollSurplusPool {
     // --- Events ---
 
-    event SurplusCollSharesClaimed(address indexed _account, uint256 _collShares);
     event SurplusCollSharesAdded(
         bytes32 indexed _cdpId,
         address indexed _account,

--- a/packages/contracts/contracts/LiquidationLibrary.sol
+++ b/packages/contracts/contracts/LiquidationLibrary.sol
@@ -334,7 +334,12 @@ contract LiquidationLibrary is CdpManagerStorage {
                 _totalColToSend
             );
             if (_collSurplus > 0) {
-                collSurplusPool.increaseSurplusCollShares(_borrower, _collSurplus);
+                collSurplusPool.increaseSurplusCollShares(
+                    _recoveryState.cdpId,
+                    _borrower,
+                    _collSurplus,
+                    0
+                );
                 _recoveryState.totalSurplusCollShares =
                     _recoveryState.totalSurplusCollShares +
                     _collSurplus;

--- a/packages/contracts/test/CollSurplusPool.js
+++ b/packages/contracts/test/CollSurplusPool.js
@@ -112,7 +112,7 @@ contract('CollSurplusPool', async accounts => {
   })
 
   it('CollSurplusPool: increaseSurplusCollShares: reverts if caller is not Cdp Manager', async () => {
-    await th.assertRevert(collSurplusPool.increaseSurplusCollShares(A, 1), 'CollSurplusPool: Caller is not CdpManager')
+    await th.assertRevert(collSurplusPool.increaseSurplusCollShares(th.RANDOM_INDEX, A, 1, 0), 'CollSurplusPool: Caller is not CdpManager')
   })  
 	  
     it('sweepToken(): move unprotected token to fee recipient', async () => {


### PR DESCRIPTION
Accounting event tweak to solve #729 for web2 team.

Small event change involving forwarding of information, given that we're doing notable audit mitigations it seemed appropriate so fit in this request.

# CollSurplusPool

`collSurplusPool.increaseSurplusCollShares` now forwards along CdpId for the event, and splits the collSurplus to add between two variables, `collateralShares` and `liquidatorRewardShares`

`collateralShares` and `liquidatorRewardShares` are both added to the total new claimable balance for the user.

```solidity
function increaseSurplusCollShares(
        bytes32 _cdpId,
        address _account,
        uint256 _collateralShares,
        uint256 _liquidatorRewardShares
    ) external;
```

This is ultimately to add addition data to this event, which is also renamed to show it is only for increases.
```solidity
event SurplusCollSharesAdded(
        bytes32 indexed _cdpId,
        address indexed _account,
        uint256 _claimableSurplusCollShares,
        uint256 _surplusCollSharesAddedFromCollateral,
        uint256 _surplusCollSharesAddedFromLiquidatorReward
    );
```

It no longer plays double-duty with the "claimed" event which was added / slightly renamed.

```solidity
event SurplusCollSharesClaimed(address indexed _account, uint256 _collShares);
```

we emit both that and `event CollSharesTransferred(address indexed _to, uint256 _amount);` to fit the paradigm established by the activePool.

This is a waste of gas to duplicate so will sync with @mrbasado to determine utility.

Needs some simple tests still