### PR TITLE
Feat/storage optimization experimental with idx moved to sorted list

### DIFF
--- a/packages/contracts/contracts/CdpManager.sol
+++ b/packages/contracts/contracts/CdpManager.sol
@@ -577,7 +577,7 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
 
         // Record the index of the new Cdpowner on their Cdp struct
         index = uint128(CdpIds.length - 1);
-        Cdps[_cdpId].arrayIndex = index;
+        sortedCdps.updateCdpArrayIdx(_cdpId, index);
 
         return index;
     }

--- a/packages/contracts/contracts/CdpManagerStorage.sol
+++ b/packages/contracts/contracts/CdpManagerStorage.sol
@@ -468,7 +468,7 @@ contract CdpManagerStorage is EbtcBase, ReentrancyGuard, ICdpManagerData, AuthNo
             "CdpManagerStorage: remove non-exist or non-active CDP!"
         );
 
-        uint128 index = Cdps[_cdpId].arrayIndex;
+        uint128 index = sortedCdps.getCdpArrayIdx(_cdpId);
         uint256 length = cdpIdsArrayLength;
         uint256 idxLast = length - 1;
 
@@ -477,7 +477,7 @@ contract CdpManagerStorage is EbtcBase, ReentrancyGuard, ICdpManagerData, AuthNo
         bytes32 idToMove = CdpIds[idxLast];
 
         CdpIds[index] = idToMove;
-        Cdps[idToMove].arrayIndex = index;
+        sortedCdps.updateCdpArrayIdx(idToMove, index);
         emit CdpArrayIndexUpdated(idToMove, index);
 
         CdpIds.pop();

--- a/packages/contracts/contracts/Interfaces/ICdpManagerData.sol
+++ b/packages/contracts/contracts/Interfaces/ICdpManagerData.sol
@@ -100,7 +100,6 @@ interface ICdpManagerData is IRecoveryModeGracePeriod {
         uint256 stake;
         uint256 liquidatorRewardShares;
         Status status;
-        uint128 arrayIndex;
     }
 
     /// 5 slots -> 3 -> could be 2 (stake + lrs + status, with arrayIndex removed?)

--- a/packages/contracts/contracts/Interfaces/ISortedCdps.sol
+++ b/packages/contracts/contracts/Interfaces/ISortedCdps.sol
@@ -90,4 +90,8 @@ interface ISortedCdps {
     ) external pure returns (bytes32);
 
     function nextCdpNonce() external view returns (uint256);
+
+    function updateCdpArrayIdx(bytes32 _cdpID, uint128 _newIdx) external;
+
+    function getCdpArrayIdx(bytes32 _cdpID) external returns (uint128);
 }

--- a/packages/contracts/contracts/Interfaces/ISortedCdps.sol
+++ b/packages/contracts/contracts/Interfaces/ISortedCdps.sol
@@ -93,5 +93,5 @@ interface ISortedCdps {
 
     function updateCdpArrayIdx(bytes32 _cdpID, uint128 _newIdx) external;
 
-    function getCdpArrayIdx(bytes32 _cdpID) external returns (uint128);
+    function getCdpArrayIdx(bytes32 _cdpID) external view returns (uint128);
 }

--- a/packages/contracts/contracts/MultiCdpGetter.sol
+++ b/packages/contracts/contracts/MultiCdpGetter.sol
@@ -88,8 +88,6 @@ contract MultiCdpGetter {
                 ,
                 _cdps[idx].stake,
                 /* status */
-                /* arrayIndex */
-                ,
                 ,
 
             ) = cdpManager.Cdps(currentCdpId);
@@ -124,8 +122,6 @@ contract MultiCdpGetter {
                 ,
                 _cdps[idx].stake,
                 /* status */
-                /* arrayIndex */
-                ,
                 ,
 
             ) = cdpManager.Cdps(currentCdpId);

--- a/packages/contracts/contracts/SortedCdps.sol
+++ b/packages/contracts/contracts/SortedCdps.sol
@@ -66,7 +66,6 @@ contract SortedCdps is ISortedCdps {
     struct Node {
         bytes32 nextId; // Id of next node (smaller NICR) in the list
         bytes32 prevId; // Id of previous node (larger NICR) in the list
-        uint128 cdpArrayIdx; // Index into the CdpIds array in CDPManagerStorage which is used in HintHelper
     }
 
     // Information for the list
@@ -75,6 +74,7 @@ contract SortedCdps is ISortedCdps {
         bytes32 tail; // Tail of the list. Also the node in the list with the smallest NICR
         uint256 size; // Current size of the list
         mapping(bytes32 => Node) nodes; // Track the corresponding ids for each node in the list
+        mapping(bytes32 => uint128) cdpIdsIndex; // Track the corresponding index for each node into the CdpIds array in CDPManagerStorage which is used in HintHelper
     }
 
     Data public data;
@@ -724,15 +724,15 @@ contract SortedCdps is ISortedCdps {
     function updateCdpArrayIdx(bytes32 _cdpID, uint128 _newIdx) external {
         _requireCallerIsCdpManagerStorage();
         require(contains(_cdpID), "SortedCdps: List doesn't contains the node");
-        data.nodes[_cdpID].cdpArrayIdx = _newIdx;
+        data.cdpIdsIndex[_cdpID] = _newIdx;
     }
 
     /// @dev Retrieve a Node(CDP)'s index into CdpIds array in CDPManagerStorage which is used in HintHelper
     /// @param _cdpID The CDP whose index to be retrieved
     /// @return The given CDP's index
-    function getCdpArrayIdx(bytes32 _cdpID) external returns (uint128) {
+    function getCdpArrayIdx(bytes32 _cdpID) external view returns (uint128) {
         require(contains(_cdpID), "SortedCdps: List doesn't contains the node");
-        return data.nodes[_cdpID].cdpArrayIdx;
+        return data.cdpIdsIndex[_cdpID];
     }
 
     // === Modifiers ===

--- a/packages/contracts/contracts/TestContracts/invariants/TargetContractSetup.sol
+++ b/packages/contracts/contracts/TestContracts/invariants/TargetContractSetup.sol
@@ -136,7 +136,8 @@ abstract contract TargetContractSetup is BaseStorageVariables, PropertiesConstan
             args = abi.encode(
                 type(uint256).max,
                 addr.cdpManagerAddress,
-                addr.borrowerOperationsAddress
+                addr.borrowerOperationsAddress,
+                addr.liquidationLibraryAddress
             );
 
             sortedCdps = SortedCdps(

--- a/packages/contracts/foundry_test/BaseFixture.sol
+++ b/packages/contracts/foundry_test/BaseFixture.sol
@@ -268,7 +268,12 @@ contract eBTCBaseFixture is
 
             // Sorted CDPS
             creationCode = type(SortedCdps).creationCode;
-            args = abi.encode(maxBytes32, addr.cdpManagerAddress, addr.borrowerOperationsAddress);
+            args = abi.encode(
+                maxBytes32,
+                addr.cdpManagerAddress,
+                addr.borrowerOperationsAddress,
+                addr.liquidationLibraryAddress
+            );
 
             sortedCdps = SortedCdps(
                 ebtcDeployer.deploy(ebtcDeployer.SORTED_CDPS(), abi.encodePacked(creationCode, args))
@@ -510,7 +515,6 @@ contract eBTCBaseFixture is
             uint256 _coll,
             uint256 _stake,
             uint256 _liquidatorRewardShares,
-            ,
 
         ) = cdpManager.Cdps(cdpId);
         uint256 _status = cdpManager.getCdpStatus(cdpId);

--- a/packages/contracts/foundry_test/CdpManager.Liquidation.t.sol
+++ b/packages/contracts/foundry_test/CdpManager.Liquidation.t.sol
@@ -29,7 +29,7 @@ contract CdpManagerLiquidationTest is eBTCBaseInvariants {
         uint256 _sumColl;
         for (uint256 i = 0; i < cdpManager.getActiveCdpsCount(); ++i) {
             bytes32 _cdpId = cdpManager.CdpIds(i);
-            (, uint256 _coll, , , , ) = cdpManager.Cdps(_cdpId);
+            (, uint256 _coll, , , ) = cdpManager.Cdps(_cdpId);
             _sumColl = _sumColl + _coll;
         }
         assertEq(

--- a/packages/contracts/test/AccessControlTest.js
+++ b/packages/contracts/test/AccessControlTest.js
@@ -226,6 +226,19 @@ contract('Access Control: Liquity functions with the caller restricted to Liquit
         assert.include(err.message, "Caller is neither BO nor CdpM")
       }
     })
+
+    // --- onlyCdpMStorage ---
+    // updateCdpArrayIdx
+    it("updateCdpArrayIdx(): reverts when called by an account that is not CdpManagerStorage", async () => {
+      // Attempt call from alice
+      try {
+        const txAlice = await sortedCdps.updateCdpArrayIdx(bob, 1, { from: alice })
+        
+      } catch (err) {
+        assert.include(err.message, "revert")
+        assert.include(err.message, "Caller is not the CdpManagerStorage")
+      }
+    })
   })
 })
 

--- a/packages/contracts/test/CdpManagerTest.js
+++ b/packages/contracts/test/CdpManagerTest.js
@@ -272,18 +272,18 @@ contract('CdpManager', async accounts => {
     assert.equal(cdp_4, _dennisCdpId)
 
     // Check correct indices recorded on the active cdp structs
-    const whale_arrayIndex = (await cdpManager.Cdps(_whaleCdpId))[5]
-    const alice_arrayIndex = (await cdpManager.Cdps(_aliceCdpId))[5]
-    const bob_arrayIndex = (await cdpManager.Cdps(_bobCdpId))[5]
-    const dennis_arrayIndex = (await cdpManager.Cdps(_dennisCdpId))[5]
-    const erin_arrayIndex = (await cdpManager.Cdps(_erinCdpId))[5]
+    const whale_arrayIndex = await sortedCdps.getCdpArrayIdx(_whaleCdpId)
+    const alice_arrayIndex = await sortedCdps.getCdpArrayIdx(_aliceCdpId)
+    const bob_arrayIndex = await sortedCdps.getCdpArrayIdx(_bobCdpId)
+    const dennis_arrayIndex = await sortedCdps.getCdpArrayIdx(_dennisCdpId)
+    const erin_arrayIndex = await sortedCdps.getCdpArrayIdx(_erinCdpId)
 
     // [W, A, B, E, D] 
-    assert.equal(whale_arrayIndex, 0)
-    assert.equal(alice_arrayIndex, 1)
-    assert.equal(bob_arrayIndex, 2)
-    assert.equal(erin_arrayIndex, 3)
-    assert.equal(dennis_arrayIndex, 4)
+    assert.equal(whale_arrayIndex.toString(), '0')
+    assert.equal(alice_arrayIndex.toString(), '1')
+    assert.equal(bob_arrayIndex.toString(), '2')
+    assert.equal(erin_arrayIndex.toString(), '3')
+    assert.equal(dennis_arrayIndex.toString(), '4')
   })
 
   it("liquidate(): updates the snapshots of total stakes and total collateral", async () => {
@@ -3881,6 +3881,7 @@ contract('CdpManager', async accounts => {
 
 
     const A_balanceBefore = await ebtcToken.balanceOf(A)
+    await th.syncTwapSystemDebt(contracts, ethers.provider);
 
     // A redeems 10 EBTC
     await th.redeemCollateral(A, contracts, dec(10, 18), GAS_PRICE)

--- a/packages/contracts/test/SortedCdpsTest.js
+++ b/packages/contracts/test/SortedCdpsTest.js
@@ -694,7 +694,7 @@ contract('SortedCdps', async accounts => {
 
     beforeEach(async () => {
       sortedCdpsTester = await SortedCdpsTester.new()
-      sortedCdps = await SortedCdps.new(2, sortedCdpsTester.address, sortedCdpsTester.address)
+      sortedCdps = await SortedCdps.new(2, sortedCdpsTester.address, sortedCdpsTester.address, sortedCdpsTester.address)
 
       await sortedCdpsTester.setSortedCdps(sortedCdps.address)
     })

--- a/packages/contracts/utils/deploymentHelpers.js
+++ b/packages/contracts/utils/deploymentHelpers.js
@@ -257,8 +257,8 @@ class DeploymentHelper {
   }
 
   static async deploySortedCdps(ebtcDeployer, _expectedAddr) {
-    const _argTypes = ['uint256', 'address', 'address'];
-    const _argValues = [0, _expectedAddr[2], _expectedAddr[3]];
+    const _argTypes = ['uint256', 'address', 'address', 'address'];
+    const _argValues = [0, _expectedAddr[2], _expectedAddr[3], _expectedAddr[1]];
 
     const _salt = await ebtcDeployer.SORTED_CDPS();
     const _deployedAddr = await this.deployViaCreate3(ebtcDeployer, _argTypes, _argValues, SortedCdps, _salt);


### PR DESCRIPTION
As part of https://github.com/ebtc-protocol/ebtc/pull/753 brainstorming, this PR tries to move `arrayIndex` in struct `Cdp` to `SortedList`:

- might reduce routine gas cost for `sload` in `CDPManager`
- further optimization target along with `SortedList` as a whole in future version of eBTC