### PR TITLE
pack Cdp struct using uint128

### DIFF
--- a/packages/contracts/contracts/CdpManager.sol
+++ b/packages/contracts/contracts/CdpManager.sol
@@ -707,14 +707,16 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
 
     // Update the last fee operation time only if time passed >= decay interval. This prevents base rate griefing.
     function _updateLastRedemptionTimestamp() internal {
-        uint256 timePassed = block.timestamp > lastRedemptionTimestamp
-            ? block.timestamp - lastRedemptionTimestamp
+        uint256 timePassed = block.timestamp > uint256(lastRedemptionTimestamp)
+            ? block.timestamp - uint256(lastRedemptionTimestamp)
             : 0;
 
         if (timePassed >= SECONDS_IN_ONE_MINUTE) {
             // Using the effective elapsed time that is consumed so far to update lastRedemptionTimestamp
             // instead block.timestamp for consistency with _calcDecayedBaseRate()
-            lastRedemptionTimestamp += _minutesPassedSinceLastRedemption() * SECONDS_IN_ONE_MINUTE;
+            lastRedemptionTimestamp += uint128(
+                _minutesPassedSinceLastRedemption() * SECONDS_IN_ONE_MINUTE
+            );
             emit LastRedemptionTimestampUpdated(block.timestamp);
         }
     }
@@ -728,8 +730,8 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
 
     function _minutesPassedSinceLastRedemption() internal view returns (uint256) {
         return
-            block.timestamp > lastRedemptionTimestamp
-                ? ((block.timestamp - lastRedemptionTimestamp) / SECONDS_IN_ONE_MINUTE)
+            block.timestamp > uint256(lastRedemptionTimestamp)
+                ? ((block.timestamp - uint256(lastRedemptionTimestamp)) / SECONDS_IN_ONE_MINUTE)
                 : 0;
     }
 

--- a/packages/contracts/contracts/CdpManagerStorage.sol
+++ b/packages/contracts/contracts/CdpManagerStorage.sol
@@ -163,7 +163,7 @@ contract CdpManagerStorage is EbtcBase, ReentrancyGuard, ICdpManagerData, AuthNo
     uint256 public stakingRewardSplit;
 
     // The timestamp of the latest fee operation (redemption or new EBTC issuance)
-    uint256 public lastRedemptionTimestamp;
+    uint128 public lastRedemptionTimestamp;
 
     mapping(bytes32 => CdpStorage) public cdpStorages;
 

--- a/packages/contracts/contracts/Interfaces/ICdpManagerData.sol
+++ b/packages/contracts/contracts/Interfaces/ICdpManagerData.sol
@@ -93,22 +93,15 @@ interface ICdpManagerData is IRecoveryModeGracePeriod {
         closedByRedemption
     }
 
-    // Store the necessary data for a cdp
-    struct Cdp {
-        uint256 debt;
-        uint256 coll;
-        uint256 stake;
-        uint256 liquidatorRewardShares;
-        Status status;
-        uint128 arrayIndex;
-    }
-
     /// 5 slots -> 3 -> could be 2 (stake + lrs + status, with arrayIndex removed?)
     struct CdpStorage {
+        // slot 1
         uint128 debt;
         uint128 coll;
+        // slot 2
         uint128 stake;
         uint128 liquidatorRewardShares;
+        // slot 3
         Status status;
         uint128 arrayIndex;
     }
@@ -275,4 +268,7 @@ interface ICdpManagerData is IRecoveryModeGracePeriod {
     ) external view returns (uint256 debt, uint256 collShares);
 
     function canLiquidateRecoveryMode(uint256 icr, uint256 tcr) external view returns (bool);
+
+    /// @dev return struct holding all accounting info about a CDP
+    function Cdps(bytes32 _cdpId) external view returns (CdpStorage memory);
 }

--- a/packages/contracts/contracts/LeverageMacroBase.sol
+++ b/packages/contracts/contracts/LeverageMacroBase.sol
@@ -12,7 +12,7 @@ import {ICdpManagerData} from "./Interfaces/ICdpManagerData.sol";
 import "./Dependencies/SafeERC20.sol";
 
 interface ICdpCdps {
-    function Cdps(bytes32) external view returns (ICdpManagerData.Cdp memory);
+    function Cdps(bytes32) external view returns (ICdpManagerData.CdpStorage memory);
 }
 
 /// @title Base implementation of the LeverageMacro
@@ -206,7 +206,7 @@ abstract contract LeverageMacroBase {
          */
         if (postCheckType == PostOperationCheck.openCdp) {
             // Check for param details
-            ICdpManagerData.Cdp memory cdpInfo = cdpManager.Cdps(expectedCdpId);
+            ICdpManagerData.CdpStorage memory cdpInfo = cdpManager.Cdps(expectedCdpId);
             _doCheckValueType(checkParams.expectedDebt, cdpInfo.debt);
             _doCheckValueType(checkParams.expectedCollateral, cdpInfo.coll);
             require(
@@ -217,7 +217,7 @@ abstract contract LeverageMacroBase {
 
         // Update CDP, Ensure the stats are as intended
         if (postCheckType == PostOperationCheck.cdpStats) {
-            ICdpManagerData.Cdp memory cdpInfo = cdpManager.Cdps(checkParams.cdpId);
+            ICdpManagerData.CdpStorage memory cdpInfo = cdpManager.Cdps(checkParams.cdpId);
 
             _doCheckValueType(checkParams.expectedDebt, cdpInfo.debt);
             _doCheckValueType(checkParams.expectedCollateral, cdpInfo.coll);
@@ -229,7 +229,7 @@ abstract contract LeverageMacroBase {
 
         // Post check type: Close, ensure it has the status we want
         if (postCheckType == PostOperationCheck.isClosed) {
-            ICdpManagerData.Cdp memory cdpInfo = cdpManager.Cdps(checkParams.cdpId);
+            ICdpManagerData.CdpStorage memory cdpInfo = cdpManager.Cdps(checkParams.cdpId);
 
             require(
                 cdpInfo.status == checkParams.expectedStatus,

--- a/packages/contracts/contracts/LiquidationLibrary.sol
+++ b/packages/contracts/contracts/LiquidationLibrary.sol
@@ -887,7 +887,7 @@ contract LiquidationLibrary is CdpManagerStorage {
         uint256 EBTCDebtNumerator = (_debt * DECIMAL_PRECISION) + lastEBTCDebtErrorRedistribution;
 
         // Get the per-unit-staked terms
-        uint256 _totalStakes = totalStakes;
+        uint256 _totalStakes = totalStakesStorage;
         uint256 EBTCDebtRewardPerUnitStaked = EBTCDebtNumerator / _totalStakes;
 
         lastEBTCDebtErrorRedistribution =

--- a/packages/contracts/contracts/LiquidationLibrary.sol
+++ b/packages/contracts/contracts/LiquidationLibrary.sol
@@ -391,7 +391,7 @@ contract LiquidationLibrary is CdpManagerStorage {
         (uint256 entireDebt, uint256 entireColl) = getSyncedDebtAndCollShares(_cdpId);
 
         // housekeeping after liquidation by closing the CDP
-        uint256 _liquidatorReward = Cdps[_cdpId].liquidatorRewardShares;
+        uint256 _liquidatorReward = cdpStorages[_cdpId].liquidatorRewardShares;
         _closeCdp(_cdpId, Status.closedByLiquidation);
 
         return (entireDebt, entireColl, _liquidatorReward);
@@ -457,7 +457,7 @@ contract LiquidationLibrary is CdpManagerStorage {
         uint256 _partialDebt,
         uint256 _partialColl
     ) internal {
-        Cdp storage _cdp = Cdps[_cdpId];
+        CdpStorage storage _cdp = cdpStorages[_cdpId];
 
         uint256 _coll = _cdp.coll;
         uint256 _debt = _cdp.debt;
@@ -466,8 +466,8 @@ contract LiquidationLibrary is CdpManagerStorage {
 
         _requireMinDebt(newDebt);
 
-        _cdp.coll = _coll - _partialColl;
-        _cdp.debt = newDebt;
+        _cdp.coll = uint128(_coll - _partialColl);
+        _cdp.debt = uint128(newDebt);
         _updateStakeAndTotalStakes(_cdpId);
     }
 
@@ -502,9 +502,9 @@ contract LiquidationLibrary is CdpManagerStorage {
             msg.sender,
             _oldDebt,
             _oldColl,
-            Cdps[_cdpId].debt,
-            Cdps[_cdpId].coll,
-            Cdps[_cdpId].stake,
+            cdpStorages[_cdpId].debt,
+            cdpStorages[_cdpId].coll,
+            cdpStorages[_cdpId].stake,
             CdpOperation.partiallyLiquidate
         );
     }
@@ -762,7 +762,7 @@ contract LiquidationLibrary is CdpManagerStorage {
         for (vars.i = _start; ; ) {
             vars.cdpId = _cdpArray[vars.i];
             // only for active cdps
-            if (vars.cdpId != bytes32(0) && Cdps[vars.cdpId].status == Status.active) {
+            if (vars.cdpId != bytes32(0) && cdpStorages[vars.cdpId].status == Status.active) {
                 vars.ICR = getSyncedICR(vars.cdpId, _price);
 
                 if (
@@ -825,7 +825,7 @@ contract LiquidationLibrary is CdpManagerStorage {
         for (vars.i = _start; ; ) {
             vars.cdpId = _cdpArray[vars.i];
             // only for active cdps
-            if (vars.cdpId != bytes32(0) && Cdps[vars.cdpId].status == Status.active) {
+            if (vars.cdpId != bytes32(0) && cdpStorages[vars.cdpId].status == Status.active) {
                 vars.ICR = getSyncedICR(vars.cdpId, _price);
 
                 if (_checkICRAgainstMCR(vars.ICR)) {

--- a/packages/contracts/contracts/MultiCdpGetter.sol
+++ b/packages/contracts/contracts/MultiCdpGetter.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 
 import "./CdpManager.sol";
 import "./SortedCdps.sol";
+import {ICdpManagerData} from "./Interfaces/ICdpManagerData.sol";
 
 /*  Helper contract for grabbing Cdp data for the front end. Not part of the core Ebtc system. */
 contract MultiCdpGetter {
@@ -83,16 +84,8 @@ contract MultiCdpGetter {
 
         for (uint256 idx = 0; idx < _count; ++idx) {
             _cdps[idx].id = currentCdpId;
-            (
-                ,
-                ,
-                _cdps[idx].stake,
-                /* status */
-                /* arrayIndex */
-                ,
-                ,
-
-            ) = cdpManager.Cdps(currentCdpId);
+            ICdpManagerData.CdpStorage memory _cdpStorage = cdpManager.Cdps(currentCdpId);
+            _cdps[idx].stake = _cdpStorage.stake;
 
             (_cdps[idx].debt, _cdps[idx].coll) = cdpManager.getSyncedDebtAndCollShares(currentCdpId);
             (_cdps[idx].snapshotEBTCDebt) = cdpManager.cdpDebtRedistributionIndex(currentCdpId);
@@ -119,16 +112,8 @@ contract MultiCdpGetter {
 
         for (uint256 idx = 0; idx < _count; ++idx) {
             _cdps[idx].id = currentCdpId;
-            (
-                ,
-                ,
-                _cdps[idx].stake,
-                /* status */
-                /* arrayIndex */
-                ,
-                ,
-
-            ) = cdpManager.Cdps(currentCdpId);
+            ICdpManagerData.CdpStorage memory _cdpStorage = cdpManager.Cdps(currentCdpId);
+            _cdps[idx].stake = _cdpStorage.stake;
 
             (_cdps[idx].debt, _cdps[idx].coll) = cdpManager.getSyncedDebtAndCollShares(currentCdpId);
             (_cdps[idx].snapshotEBTCDebt) = cdpManager.cdpDebtRedistributionIndex(currentCdpId);

--- a/packages/contracts/contracts/TestContracts/ActivePoolTester.sol
+++ b/packages/contracts/contracts/TestContracts/ActivePoolTester.sol
@@ -26,11 +26,11 @@ contract ActivePoolTester is ActivePool {
     bytes4 public constant FUNC_SIG_MAX_FL_FEE = 0x246d4569; //setMaxFeeBps(uint256)
 
     function unprotectedIncreaseSystemDebt(uint256 _amount) public {
-        systemDebt = systemDebt + _amount;
+        systemDebt = uint128(uint256(systemDebt) + _amount);
     }
 
     function unprotectedReceiveColl(uint256 _amount) public {
-        systemCollShares = systemCollShares + _amount;
+        systemCollShares = uint128(uint256(systemCollShares) + _amount);
     }
 
     function unprotectedIncreaseSystemDebtAndUpdate(uint256 _amount) external {
@@ -46,11 +46,11 @@ contract ActivePoolTester is ActivePool {
     }
 
     function unprotectedallocateSystemCollSharesToFeeRecipient(uint256 _shares) external {
-        systemCollShares = systemCollShares - _shares;
-        feeRecipientCollShares = feeRecipientCollShares + _shares;
+        systemCollShares = uint128(uint256(systemCollShares) - _shares);
+        feeRecipientCollShares = uint128(uint256(feeRecipientCollShares) + _shares);
 
-        emit SystemCollSharesUpdated(systemCollShares);
-        emit FeeRecipientClaimableCollSharesIncreased(feeRecipientCollShares, _shares);
+        emit SystemCollSharesUpdated(uint256(systemCollShares));
+        emit FeeRecipientClaimableCollSharesIncreased(uint256(feeRecipientCollShares), _shares);
     }
 
     function unprotectedSetTwapTrackVal(uint256 _val) public {

--- a/packages/contracts/contracts/TestContracts/CDPManagerTester.sol
+++ b/packages/contracts/contracts/TestContracts/CDPManagerTester.sol
@@ -80,7 +80,7 @@ contract CdpManagerTester is CdpManager {
     }
 
     function setLastFeeOpTimeToNow() external {
-        lastRedemptionTimestamp = block.timestamp;
+        lastRedemptionTimestamp = uint128(block.timestamp);
     }
 
     function getDecayedBaseRate() external view returns (uint256) {

--- a/packages/contracts/foundry_test/BaseFixture.sol
+++ b/packages/contracts/foundry_test/BaseFixture.sol
@@ -32,6 +32,7 @@ import {BeforeAfterWithLogging} from "./utils/BeforeAfterWithLogging.sol";
 import {FoundryAsserts} from "./utils/FoundryAsserts.sol";
 import {Pretty, Strings} from "../contracts/TestContracts/Pretty.sol";
 import {IBaseTwapWeightedObserver} from "../contracts/Interfaces/IBaseTwapWeightedObserver.sol";
+import {ICdpManagerData} from "../contracts/Interfaces/ICdpManagerData.sol";
 import {EbtcMath} from "../contracts/Dependencies/EbtcMath.sol";
 
 contract eBTCBaseFixture is
@@ -505,14 +506,11 @@ contract eBTCBaseFixture is
 
     /// @dev Ensure data fields for Cdp are in expected post-close state
     function _assertCdpClosed(bytes32 cdpId, uint256 expectedStatus) internal {
-        (
-            uint256 _debt,
-            uint256 _coll,
-            uint256 _stake,
-            uint256 _liquidatorRewardShares,
-            ,
-
-        ) = cdpManager.Cdps(cdpId);
+        ICdpManagerData.CdpStorage memory _cdpStorage = cdpManager.Cdps(cdpId);
+        uint256 _debt = _cdpStorage.debt;
+        uint256 _coll = _cdpStorage.coll;
+        uint256 _stake = _cdpStorage.stake;
+        uint256 _liquidatorRewardShares = _cdpStorage.liquidatorRewardShares;
         uint256 _status = cdpManager.getCdpStatus(cdpId);
 
         assertTrue(_debt == 0);

--- a/packages/contracts/foundry_test/CdpManager.Liquidation.t.sol
+++ b/packages/contracts/foundry_test/CdpManager.Liquidation.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 import {console2 as console} from "forge-std/console2.sol";
 
 import {eBTCBaseInvariants} from "./BaseInvariants.sol";
+import {ICdpManagerData} from "../contracts/Interfaces/ICdpManagerData.sol";
 
 contract CdpManagerLiquidationTest is eBTCBaseInvariants {
     address payable[] users;
@@ -29,7 +30,8 @@ contract CdpManagerLiquidationTest is eBTCBaseInvariants {
         uint256 _sumColl;
         for (uint256 i = 0; i < cdpManager.getActiveCdpsCount(); ++i) {
             bytes32 _cdpId = cdpManager.CdpIds(i);
-            (, uint256 _coll, , , , ) = cdpManager.Cdps(_cdpId);
+            ICdpManagerData.CdpStorage memory _cdpStorage = cdpManager.Cdps(_cdpId);
+            uint256 _coll = _cdpStorage.coll;
             _sumColl = _sumColl + _coll;
         }
         assertEq(

--- a/packages/contracts/test/BorrowerOperationsTest.js
+++ b/packages/contracts/test/BorrowerOperationsTest.js
@@ -296,8 +296,8 @@ contract('BorrowerOperations', async accounts => {
       await openCdp({ ICR: toBN(dec(2, 18)), extraParams: { from: alice } })
       const aliceIndex = await sortedCdps.cdpOfOwnerByIndex(alice,0)
       const alice_Cdp_Before = await cdpManager.Cdps(aliceIndex)
-      const coll_before = alice_Cdp_Before[1]
-      const status_Before = alice_Cdp_Before[4]
+      const coll_before = web3.utils.toBN(alice_Cdp_Before[1])
+      const status_Before = web3.utils.toBN(alice_Cdp_Before[4])
 
       // check status before
       assert.equal(status_Before, 1)
@@ -306,8 +306,8 @@ contract('BorrowerOperations', async accounts => {
       await borrowerOperations.addColl(aliceIndex, th.DUMMY_BYTES32, th.DUMMY_BYTES32, dec(1, 'ether'), { from: alice })
 
       const alice_Cdp_After = await cdpManager.Cdps(aliceIndex)
-      const coll_After = alice_Cdp_After[1]
-      const status_After = alice_Cdp_After[4]
+      const coll_After = web3.utils.toBN(alice_Cdp_After[1])
+      const status_After = web3.utils.toBN(alice_Cdp_After[4])
 
       // check coll increases by correct amount,and status remains active
       assert.isTrue(coll_After.eq(coll_before.add(toBN(dec(1, 'ether')))))
@@ -340,7 +340,7 @@ contract('BorrowerOperations', async accounts => {
       const aliceIndex = await sortedCdps.cdpOfOwnerByIndex(alice,0)
 
       const alice_Cdp_Before = await cdpManager.Cdps(aliceIndex)
-      const alice_Stake_Before = alice_Cdp_Before[2]
+      const alice_Stake_Before = web3.utils.toBN(alice_Cdp_Before[2])
       const totalStakes_Before = (await cdpManager.totalStakes())
 
       assert.isTrue(totalStakes_Before.eq(alice_Stake_Before))
@@ -350,7 +350,7 @@ contract('BorrowerOperations', async accounts => {
 
       // Check stake and total stakes get updated
       const alice_Cdp_After = await cdpManager.Cdps(aliceIndex)
-      const alice_Stake_After = alice_Cdp_After[2]
+      const alice_Stake_After = web3.utils.toBN(alice_Cdp_After[2])
       const totalStakes_After = (await cdpManager.totalStakes())
 
       assert.isTrue(alice_Stake_After.eq(alice_Stake_Before.add(toBN(dec(2, 'ether')))))
@@ -527,7 +527,7 @@ contract('BorrowerOperations', async accounts => {
       await borrowerOperations.addColl(aliceIndex, th.DUMMY_BYTES32, th.DUMMY_BYTES32, collTopUp, { from: alice })
 
       // Check Alice's collateral
-      const aliceCollAfter = (await cdpManager.Cdps(aliceIndex))[1]
+      const aliceCollAfter = web3.utils.toBN((await cdpManager.Cdps(aliceIndex))[1])
       assert.isTrue(aliceCollAfter.eq(aliceCollBefore.add(collTopUp)))
     })
 
@@ -752,7 +752,7 @@ contract('BorrowerOperations', async accounts => {
       assert.isTrue(aliceColl.gt(toBN('0')))
 
       const alice_Cdp_Before = await cdpManager.Cdps(aliceIndex)
-      const alice_Stake_Before = alice_Cdp_Before[2]
+      const alice_Stake_Before = web3.utils.toBN(alice_Cdp_Before[2])
       const totalStakes_Before = (await cdpManager.totalStakes())
 
       assert.isTrue(alice_Stake_Before.eq(aliceColl))
@@ -763,7 +763,7 @@ contract('BorrowerOperations', async accounts => {
 
       // Check stake and total stakes get updated
       const alice_Cdp_After = await cdpManager.Cdps(aliceIndex)
-      const alice_Stake_After = alice_Cdp_After[2]
+      const alice_Stake_After = web3.utils.toBN(alice_Cdp_After[2])
       const totalStakes_After = (await cdpManager.totalStakes())
 
       assert.isTrue(alice_Stake_After.eq(alice_Stake_Before.sub(toBN(dec(1, 17)))))

--- a/packages/contracts/test/CdpManagerTest.js
+++ b/packages/contracts/test/CdpManagerTest.js
@@ -956,8 +956,8 @@ contract('CdpManager', async accounts => {
 
     /* Though Bob's true ICR (including pending rewards) is below the MCR, 
     check that Bob's raw coll and debt has not changed, and that his "raw" ICR is above the MCR */
-    const bob_Coll = (await cdpManager.Cdps(_bobCdpId))[1]
-    const bob_Debt = (await cdpManager.Cdps(_bobCdpId))[0]
+    const bob_Coll = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
+    const bob_Debt = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[0])
 
     const bob_rawICR = bob_Coll.mul(toBN(dec(100, 18))).div(bob_Debt)
     assert.isTrue(bob_rawICR.gte(mv._MCR))
@@ -1369,8 +1369,8 @@ contract('CdpManager', async accounts => {
     assert.isTrue(carol_ICR_After.lte(mv._MCR))
 
     /* Though Bob's true ICR (including pending rewards) is below the MCR, check that Bob's raw coll and debt has not changed */
-    const bob_Coll = (await cdpManager.Cdps(_bobCdpId))[1]
-    const bob_Debt = (await cdpManager.Cdps(_bobCdpId))[0]
+    const bob_Coll = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
+    const bob_Debt = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[0])
 
     const bob_rawICR = bob_Coll.mul(toBN(dec(100, 18))).div(bob_Debt)
     assert.isTrue(bob_rawICR.gte(mv._MCR))
@@ -3881,6 +3881,7 @@ contract('CdpManager', async accounts => {
 
 
     const A_balanceBefore = await ebtcToken.balanceOf(A)
+    await th.syncTwapSystemDebt(contracts, ethers.provider);
 
     // A redeems 10 EBTC
     await th.redeemCollateral(A, contracts, dec(10, 18), GAS_PRICE)

--- a/packages/contracts/test/CdpManager_LiquidationRewardsTest.js
+++ b/packages/contracts/test/CdpManager_LiquidationRewardsTest.js
@@ -568,10 +568,10 @@ contract('CdpManager - Redistribution reward calculations', async accounts => {
     let _aliceDebtRedistributedToBob = _aliceDebtRedistributed.mul((await cdpManager.getCdpStake(_bobCdpId))).div(_totalStakesAfterAliceLiq);
 
     // Expect Bob now holds all Ether and EBTCDebt in the system: 2 + 0.4975+0.4975*0.995+0.995 Ether and 110*3 EBTC (10 each for gas compensation)
-    const bob_Coll = ((await cdpManager.Cdps(_bobCdpId))[1]).toString()
+    const bob_Coll = web3.utils.toBN(((await cdpManager.Cdps(_bobCdpId))[1]).toString())
     
     let _pendingDebtRewards = await cdpManager.getPendingRedistributedDebt(_bobCdpId);
-    const bob_EBTCDebt = ((await cdpManager.Cdps(_bobCdpId))[0]
+    const bob_EBTCDebt = (web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[0])
       .add(_pendingDebtRewards))
       .toString()
 
@@ -649,17 +649,17 @@ contract('CdpManager - Redistribution reward calculations', async accounts => {
     totalColl: 4.99 ETH
     totalDebt 380 EBTC (includes 50 each for gas compensation)
     */
-    const bob_Coll = ((await cdpManager.Cdps(_bobCdpId))[1]).toString()
+    const bob_Coll = web3.utils.toBN(((await cdpManager.Cdps(_bobCdpId))[1]).toString())
 
     let _bobPendingDebtRewards = await cdpManager.getPendingRedistributedDebt(_bobCdpId);
-    const bob_EBTCDebt = ((await cdpManager.Cdps(_bobCdpId))[0]
+    const bob_EBTCDebt = (web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[0])
       .add(_bobPendingDebtRewards))
       .toString()
 
-    const alice_Coll = ((await cdpManager.Cdps(_aliceCdpId))[1]).toString()
+    const alice_Coll = web3.utils.toBN(((await cdpManager.Cdps(_aliceCdpId))[1]).toString())
 
     let _alicePendingDebtRewards = await cdpManager.getPendingRedistributedDebt(_aliceCdpId);
-    const alice_EBTCDebt = ((await cdpManager.Cdps(_aliceCdpId))[0]
+    const alice_EBTCDebt = (web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[0])
       .add(_alicePendingDebtRewards))
       .toString()
 
@@ -928,10 +928,10 @@ contract('CdpManager - Redistribution reward calculations', async accounts => {
 
     // Expect Bob now holds all Ether and EBTCDebt in the system: 2.5 Ether and 300 EBTC
     // 1 + 0.995/2 - 0.5 + 1.4975*0.995
-    const bob_Coll = ((await cdpManager.Cdps(_bobCdpId))[1]).toString()
+    const bob_Coll = web3.utils.toBN(((await cdpManager.Cdps(_bobCdpId))[1]).toString())
 
     let _bobPendingDebtRewards = await cdpManager.getPendingRedistributedDebt(_bobCdpId);
-    const bob_EBTCDebt = ((await cdpManager.Cdps(_bobCdpId))[0]
+    const bob_EBTCDebt = (web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[0])
       .add(_bobPendingDebtRewards))
       .toString()
 	
@@ -1018,17 +1018,17 @@ contract('CdpManager - Redistribution reward calculations', async accounts => {
     totalColl: 3.49 ETH
     totalDebt 380 EBTC (Includes 50 in each cdp for gas compensation)
     */
-    const bob_Coll = ((await cdpManager.Cdps(_bobCdpId))[1]).toString()
+    const bob_Coll = web3.utils.toBN(((await cdpManager.Cdps(_bobCdpId))[1]).toString())
 
     let _bobPendingDebtRewards = await cdpManager.getPendingRedistributedDebt(_bobCdpId);
-    const bob_EBTCDebt = ((await cdpManager.Cdps(_bobCdpId))[0]
+    const bob_EBTCDebt = (web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[0])
       .add(_bobPendingDebtRewards))
       .toString()
 
-    const alice_Coll = ((await cdpManager.Cdps(_aliceCdpId))[1]).toString()
+    const alice_Coll = web3.utils.toBN(((await cdpManager.Cdps(_aliceCdpId))[1]).toString())
 
     let _alicePendingDebtRewards = await cdpManager.getPendingRedistributedDebt(_aliceCdpId);
-    const alice_EBTCDebt = ((await cdpManager.Cdps(_aliceCdpId))[0]
+    const alice_EBTCDebt = (web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[0])
       .add(_alicePendingDebtRewards))
       .toString()
 

--- a/packages/contracts/test/CdpManager_RecoveryModeTest.js
+++ b/packages/contracts/test/CdpManager_RecoveryModeTest.js
@@ -1004,7 +1004,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(recoveryMode)
 
     // Check Bob's Cdp is active
-    const bob_CdpStatus_Before = (await cdpManager.Cdps(_bobCdpId))[4]
+    const bob_CdpStatus_Before = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[4])
     const bob_Cdp_isInSortedList_Before = await sortedCdps.contains(_bobCdpId)
 
     assert.equal(bob_CdpStatus_Before, 1) // status enum element 1 corresponds to "Active"
@@ -1018,7 +1018,7 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     /* Since the pool only contains 100 EBTC, and Bob's pre-liquidation debt was 250 EBTC,
     expect Bob's cdp to remain untouched, and remain active after liquidation */
 
-    const bob_CdpStatus_After = (await cdpManager.Cdps(_bobCdpId))[4]
+    const bob_CdpStatus_After = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[4])
     const bob_Cdp_isInSortedList_After = await sortedCdps.contains(_bobCdpId)
 
     assert.equal(bob_CdpStatus_After, 3) // status enum element 3 corresponds to "closed"
@@ -1232,8 +1232,8 @@ contract('CdpManager - in Recovery Mode', async accounts => {
 
     assert.isTrue(await th.checkRecoveryMode(contracts))
 
-    const bob_Coll_Before = (await cdpManager.Cdps(_bobCdpId))[1]
-    const bob_Debt_Before = (await cdpManager.Cdps(_bobCdpId))[0]
+    const bob_Coll_Before = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
+    const bob_Debt_Before = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[0])
 
     // confirm Bob is last cdp in list, and has >110% ICR
     assert.equal((await sortedCdps.getLast()).toString(), _bobCdpId)
@@ -1247,8 +1247,8 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isFalse(await sortedCdps.contains(_bobCdpId))
 
     // Check Bob's collateral and debt remains the same
-    const bob_Coll_After = (await cdpManager.Cdps(_bobCdpId))[1]
-    const bob_Debt_After = (await cdpManager.Cdps(_bobCdpId))[0]
+    const bob_Coll_After = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
+    const bob_Debt_After = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[0])
     assert.isTrue(bob_Coll_After.lt(bob_Coll_Before))
     assert.isTrue(bob_Debt_After.lt(bob_Debt_Before))
 
@@ -1600,8 +1600,8 @@ contract('CdpManager - in Recovery Mode', async accounts => {
 
     /* Though Bob's true ICR (including pending rewards) is below the MCR, 
     check that Bob's raw coll and debt has not changed, and that his "raw" ICR is above the MCR */
-    const bob_Coll = (await cdpManager.Cdps(_bobCdpId))[1]
-    const bob_Debt = (await cdpManager.Cdps(_bobCdpId))[0]
+    const bob_Coll = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
+    const bob_Debt = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[0])
 
     const bob_rawICR = bob_Coll.mul(th.toBN(dec(100, 18))).div(bob_Debt)
     assert.isTrue(bob_rawICR.gte(mv._MCR))
@@ -2396,8 +2396,8 @@ contract('CdpManager - in Recovery Mode', async accounts => {
 
     /* Though Bob's true ICR (including pending rewards) is below the MCR, 
    check that Bob's raw coll and debt has not changed, and that his "raw" ICR is above the MCR */
-    const bob_Coll = (await cdpManager.Cdps(_bobCdpId))[1]
-    const bob_Debt = (await cdpManager.Cdps(_bobCdpId))[0]
+    const bob_Coll = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
+    const bob_Debt = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[0])
 
     const bob_rawICR = bob_Coll.mul(th.toBN(dec(100, 18))).div(bob_Debt)
     assert.isTrue(bob_rawICR.gte(mv._MCR))
@@ -2601,8 +2601,8 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(await sortedCdps.contains(_whaleCdpId))
 
     // Check A's collateral and debt remain the same
-    const entireColl_A = (await cdpManager.Cdps(_aliceCdpId))[1]
-    const entireDebt_A = (await cdpManager.Cdps(_aliceCdpId))[0].add((await cdpManager.getPendingRedistributedDebt(_aliceCdpId)))
+    const entireColl_A = web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[1])
+    const entireDebt_A = web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[0]).add((await cdpManager.getPendingRedistributedDebt(_aliceCdpId)))
 
     assert.equal(entireColl_A.toString(), '0')
     assert.equal(entireDebt_A.toString(), '0')
@@ -4002,9 +4002,9 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     let _carolCdpId = await sortedCdps.cdpOfOwnerByIndex(carol, 0);
     let _dennisCdpId = await sortedCdps.cdpOfOwnerByIndex(dennis, 0);
 
-    const bobColl_Before = (await cdpManager.Cdps(_bobCdpId))[1]
-    const carolColl_Before = (await cdpManager.Cdps(_carolCdpId))[1]
-    const dennisColl_Before = (await cdpManager.Cdps(_dennisCdpId))[1]
+    const bobColl_Before = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
+    const carolColl_Before = web3.utils.toBN((await cdpManager.Cdps(_carolCdpId))[1])
+    const dennisColl_Before = web3.utils.toBN((await cdpManager.Cdps(_dennisCdpId))[1])
 
     await openCdp({ ICR: toBN(dec(228, 16)), extraParams: { from: erin } })
     await openCdp({ ICR: toBN(dec(230, 16)), extraParams: { from: freddy } })
@@ -4048,13 +4048,13 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.equal((await cdpManager.Cdps(_carolCdpId))[4], '3')
 
     // Confirm D, B, C coll & debt have not changed
-    const dennisDebt_After = (await cdpManager.Cdps(_dennisCdpId))[0].add((await cdpManager.getPendingRedistributedDebt(dennis)))
-    const bobDebt_After = (await cdpManager.Cdps(_bobCdpId))[0].add((await cdpManager.getPendingRedistributedDebt(bob)))
-    const carolDebt_After = (await cdpManager.Cdps(_carolCdpId))[0].add((await cdpManager.getPendingRedistributedDebt(carol)))
+    const dennisDebt_After = web3.utils.toBN((await cdpManager.Cdps(_dennisCdpId))[0]).add((await cdpManager.getPendingRedistributedDebt(dennis)))
+    const bobDebt_After = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[0]).add((await cdpManager.getPendingRedistributedDebt(bob)))
+    const carolDebt_After = web3.utils.toBN((await cdpManager.Cdps(_carolCdpId))[0]).add((await cdpManager.getPendingRedistributedDebt(carol)))
 
-    const dennisColl_After = (await cdpManager.Cdps(_dennisCdpId))[1]  
-    const bobColl_After = (await cdpManager.Cdps(_bobCdpId))[1]
-    const carolColl_After = (await cdpManager.Cdps(_carolCdpId))[1]
+    const dennisColl_After = web3.utils.toBN((await cdpManager.Cdps(_dennisCdpId))[1])  
+    const bobColl_After = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
+    const carolColl_After = web3.utils.toBN((await cdpManager.Cdps(_carolCdpId))[1])
 
     assert.isTrue(dennisColl_After.lt(dennisColl_Before))
     assert.isTrue(bobColl_After.lt(bobColl_Before))
@@ -4106,12 +4106,12 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     // Confirm Recovery Mode
     assert.isTrue(await th.checkRecoveryMode(contracts))
 
-    const G_collBefore = (await cdpManager.Cdps(_gCdpId))[1]
-    const G_debtBefore = (await cdpManager.Cdps(_gCdpId))[0]
-    const H_collBefore = (await cdpManager.Cdps(_hCdpId))[1]
-    const H_debtBefore = (await cdpManager.Cdps(_hCdpId))[0]
-    const I_collBefore = (await cdpManager.Cdps(_iCdpId))[1]
-    const I_debtBefore = (await cdpManager.Cdps(_iCdpId))[0]
+    const G_collBefore = web3.utils.toBN((await cdpManager.Cdps(_gCdpId))[1])
+    const G_debtBefore = web3.utils.toBN((await cdpManager.Cdps(_gCdpId))[0])
+    const H_collBefore = web3.utils.toBN((await cdpManager.Cdps(_hCdpId))[1])
+    const H_debtBefore = web3.utils.toBN((await cdpManager.Cdps(_hCdpId))[0])
+    const I_collBefore = web3.utils.toBN((await cdpManager.Cdps(_iCdpId))[1])
+    const I_debtBefore = web3.utils.toBN((await cdpManager.Cdps(_iCdpId))[0])
 
     const ICR_A = await cdpManager.getCachedICR(_aCdpId, price) 
     const ICR_B = await cdpManager.getCachedICR(_bCdpId, price) 
@@ -4144,13 +4144,13 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(await sortedCdps.contains(_hCdpId))
     assert.isTrue(await sortedCdps.contains(_iCdpId))
 
-    // Check G, H, I coll and debt have not changed
-    assert.equal(G_collBefore.eq(await cdpManager.Cdps(_gCdpId))[1])
-    assert.equal(G_debtBefore.eq(await cdpManager.Cdps(_gCdpId))[0])
-    assert.equal(H_collBefore.eq(await cdpManager.Cdps(_hCdpId))[1])
-    assert.equal(H_debtBefore.eq(await cdpManager.Cdps(_hCdpId))[0])
-    assert.equal(I_collBefore.eq(await cdpManager.Cdps(_iCdpId))[1])
-    assert.equal(I_debtBefore.eq(await cdpManager.Cdps(_iCdpId))[0])
+    // Check G, H, I coll and debt have not changeds
+    assert.isTrue(G_collBefore.eq(web3.utils.toBN((await cdpManager.Cdps(_gCdpId))[1])))
+    assert.isTrue(G_debtBefore.eq(web3.utils.toBN((await cdpManager.Cdps(_gCdpId))[0])))
+    assert.isTrue(H_collBefore.eq(web3.utils.toBN((await cdpManager.Cdps(_hCdpId))[1])))
+    assert.isTrue(H_debtBefore.eq(web3.utils.toBN((await cdpManager.Cdps(_hCdpId))[0])))
+    assert.isTrue(I_collBefore.eq(web3.utils.toBN((await cdpManager.Cdps(_iCdpId))[1])))
+    assert.isTrue(I_debtBefore.eq(web3.utils.toBN((await cdpManager.Cdps(_iCdpId))[0])))
 
     // Confirm Recovery Mode
     assert.isTrue(await th.checkRecoveryMode(contracts))
@@ -4177,8 +4177,8 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(await sortedCdps.contains(_iCdpId))
 
     // Check coll and debt have not changed
-    assert.equal(I_collBefore.eq(await cdpManager.Cdps(_iCdpId))[1])
-    assert.equal(I_debtBefore.eq(await cdpManager.Cdps(_iCdpId))[0])
+    assert.isTrue(I_collBefore.eq(web3.utils.toBN((await cdpManager.Cdps(_iCdpId))[1])))
+    assert.isTrue(I_debtBefore.eq(web3.utils.toBN((await cdpManager.Cdps(_iCdpId))[0])))
 
     // Confirm Recovery Mode
     assert.isTrue(await th.checkRecoveryMode(contracts))
@@ -4197,13 +4197,13 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     await ethers.provider.send("evm_increaseTime", [901]);
     await ethers.provider.send("evm_mine");
     
-    const dEbtBefore = (await cdpManager.Cdps(_eCdpId))[0]
+    const dEbtBefore = web3.utils.toBN((await cdpManager.Cdps(_eCdpId))[0])
 
     await debtToken.transfer(owner, toBN((await debtToken.balanceOf(F)).toString()), {from: F});	
     await debtToken.transfer(owner, toBN((await debtToken.balanceOf(E)).toString()), {from: E});
     await cdpManager.batchLiquidateCdps([_bCdpId, _iCdpId, _eCdpId])
     
-    const dEbtAfter = (await cdpManager.Cdps(_eCdpId))[0]
+    const dEbtAfter = web3.utils.toBN((await cdpManager.Cdps(_eCdpId))[0])
     
     const dEbtDelta = dEbtBefore.sub(dEbtAfter)
 
@@ -4217,8 +4217,8 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(await sortedCdps.contains(_iCdpId))
 
     // Check coll and debt have not changed
-    assert.equal(I_collBefore.eq(await cdpManager.Cdps(_iCdpId))[1])
-    assert.equal(I_debtBefore.eq(await cdpManager.Cdps(_iCdpId))[0])
+    assert.isTrue(I_collBefore.eq(web3.utils.toBN((await cdpManager.Cdps(_iCdpId))[1])))
+    assert.isTrue(I_debtBefore.eq(web3.utils.toBN((await cdpManager.Cdps(_iCdpId))[0])))
   })
 
   it('batchLiquidateCdps(): emits liquidation event with correct values when all cdps have ICR > 110% and liquidator covers a subset of cdps', async () => {
@@ -4358,8 +4358,8 @@ contract('CdpManager - in Recovery Mode', async accounts => {
     assert.isTrue(await sortedCdps.contains(_whaleCdpId))
 
     // Check A's collateral and debt are the same
-    const entireColl_A = (await cdpManager.Cdps(_aliceCdpId))[1]
-    const entireDebt_A = (await cdpManager.Cdps(_aliceCdpId))[0].add((await cdpManager.getPendingRedistributedDebt(_aliceCdpId)))
+    const entireColl_A = web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[1])
+    const entireDebt_A = web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[0]).add((await cdpManager.getPendingRedistributedDebt(_aliceCdpId)))
 
     assert.equal(entireColl_A.toString(), '0')
     th.assertIsApproximatelyEqual(entireDebt_A.toString(), '0')

--- a/packages/contracts/test/GasCompensationTest.js
+++ b/packages/contracts/test/GasCompensationTest.js
@@ -356,7 +356,7 @@ contract('Gas compensation tests', async accounts => {
     and (1 - 0.05000025000125001) = 0.94999974999875 ETH remainder liquidated */
 
     // Check collateral value in USD is > $10
-    const aliceColl = (await cdpManager.Cdps(_aliceCdpId))[1]
+    const aliceColl = web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[1])
 
     assert.isFalse(await th.checkRecoveryMode(contracts))
 
@@ -388,7 +388,7 @@ contract('Gas compensation tests', async accounts => {
     and (15 - 0.666666666666666666) ETH remainder liquidated */
 
     // Check collateral value in USD is > $10
-    const bobColl = (await cdpManager.Cdps(_bobCdpId))[1]
+    const bobColl = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
 
     assert.isFalse(await th.checkRecoveryMode(contracts))
 
@@ -433,7 +433,7 @@ contract('Gas compensation tests', async accounts => {
     and (10.001 - 0.050005) ETH remainder liquidated */
 
     // Check value of 0.5% of collateral in USD is > $10
-    const aliceColl = (await cdpManager.Cdps(_aliceCdpId))[1]
+    const aliceColl = web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[1])
     const _0pt5percent_aliceColl = toBN(liqReward.toString());//aliceColl.div(web3.utils.toBN('200'))
 
     assert.isFalse(await th.checkRecoveryMode(contracts))
@@ -462,7 +462,7 @@ contract('Gas compensation tests', async accounts => {
    and (37.5 - 0.1875 ETH) ETH remainder liquidated */
 
     // Check value of 0.5% of collateral in USD is > $10
-    const bobColl = (await cdpManager.Cdps(_bobCdpId))[1]
+    const bobColl = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
     const _0pt5percent_bobColl = toBN(liqReward.toString());//bobColl.div(web3.utils.toBN('200'))
 
     assert.isFalse(await th.checkRecoveryMode(contracts))
@@ -659,8 +659,8 @@ contract('Gas compensation tests', async accounts => {
     const price_1 = await priceFeed.getPrice()
 
     // Check value of 0.5% of collateral in USD is > $10
-    const aliceColl = (await cdpManager.Cdps(_aliceCdpId))[1]
-    const aliceDebt = (await cdpManager.Cdps(_aliceCdpId))[0]
+    const aliceColl = web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[1])
+    const aliceDebt = web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[0])
 
     assert.isFalse(await th.checkRecoveryMode(contracts))
 
@@ -690,8 +690,8 @@ contract('Gas compensation tests', async accounts => {
    and (37.5 - 0.1875 ETH) ETH remainder liquidated */
 
     // Check value of 0.5% of collateral in USD is > $10
-    const bobColl = (await cdpManager.Cdps(_bobCdpId))[1]
-    const bobDebt = (await cdpManager.Cdps(_bobCdpId))[0]
+    const bobColl = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
+    const bobDebt = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[0])
 
     assert.isFalse(await th.checkRecoveryMode(contracts))
 
@@ -751,10 +751,10 @@ contract('Gas compensation tests', async accounts => {
 
 
     // --- Check value of of A's collateral is < $10, and value of B,C,D collateral are > $10  ---
-    const aliceColl = (await cdpManager.Cdps(_aliceCdpId))[1]
-    const bobColl = (await cdpManager.Cdps(_bobCdpId))[1]
-    const carolColl = (await cdpManager.Cdps(_carolCdpId))[1]
-    const dennisColl = (await cdpManager.Cdps(_dennisCdpId))[1]
+    const aliceColl = web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[1])
+    const bobColl = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
+    const carolColl = web3.utils.toBN((await cdpManager.Cdps(_carolCdpId))[1])
+    const dennisColl = web3.utils.toBN((await cdpManager.Cdps(_dennisCdpId))[1])
 
     // --- Check value of 0.5% of A, B, and C's collateral is <$10, and value of 0.5% of D's collateral is > $10 ---
     const _0pt5percent_aliceColl = aliceColl.div(web3.utils.toBN('200'))
@@ -911,10 +911,10 @@ contract('Gas compensation tests', async accounts => {
 
 
     // --- Check value of of A's collateral is < $10, and value of B,C,D collateral are > $10  ---
-    const aliceColl = (await cdpManager.Cdps(_aliceCdpId))[1]
-    const bobColl = (await cdpManager.Cdps(_bobCdpId))[1]
-    const carolColl = (await cdpManager.Cdps(_carolCdpId))[1]
-    const dennisColl = (await cdpManager.Cdps(_dennisCdpId))[1]
+    const aliceColl = web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[1])
+    const bobColl = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
+    const carolColl = web3.utils.toBN((await cdpManager.Cdps(_carolCdpId))[1])
+    const dennisColl = web3.utils.toBN((await cdpManager.Cdps(_dennisCdpId))[1])
 
     // --- Check value of 0.5% of A, B, and C's collateral is <$10, and value of 0.5% of D's collateral is > $10 ---
     const _0pt5percent_aliceColl = aliceColl.div(web3.utils.toBN('200'))
@@ -986,10 +986,10 @@ contract('Gas compensation tests', async accounts => {
     assert.isTrue((await cdpManager.getCachedICR(_carolCdpId, price)).lt(mv._MCR))
     assert.isTrue((await cdpManager.getCachedICR(_dennisCdpId, price)).lt(mv._MCR))
 
-    const aliceColl = (await cdpManager.Cdps(_aliceCdpId))[1]
-    const bobColl = (await cdpManager.Cdps(_bobCdpId))[1]
-    const carolColl = (await cdpManager.Cdps(_carolCdpId))[1]
-    const dennisColl = (await cdpManager.Cdps(_dennisCdpId))[1]
+    const aliceColl = web3.utils.toBN((await cdpManager.Cdps(_aliceCdpId))[1])
+    const bobColl = web3.utils.toBN((await cdpManager.Cdps(_bobCdpId))[1])
+    const carolColl = web3.utils.toBN((await cdpManager.Cdps(_carolCdpId))[1])
+    const dennisColl = web3.utils.toBN((await cdpManager.Cdps(_dennisCdpId))[1])
 
     // --- Check value of 0.5% of A, B, and C's collateral is <$10, and value of 0.5% of D's collateral is > $10 ---
     const _0pt5percent_aliceColl = aliceColl.div(web3.utils.toBN('200'))
@@ -1195,4 +1195,3 @@ contract('Gas compensation tests', async accounts => {
     }
   })
 })
-

--- a/packages/contracts/utils/testHelpers.js
+++ b/packages/contracts/utils/testHelpers.js
@@ -583,8 +583,8 @@ class TestHelper {
 
   static async getEntireCollAndDebt(contracts, account) {
     // console.log(`account: ${account}`)
-    const rawColl = (await contracts.cdpManager.Cdps(account))[1]
-    const rawDebt = (await contracts.cdpManager.Cdps(account))[0]
+    const rawColl = web3.utils.toBN((await contracts.cdpManager.Cdps(account))[1])
+    const rawDebt = web3.utils.toBN((await contracts.cdpManager.Cdps(account))[0])
     const pendingRedistributedDebt = (await contracts.cdpManager.getPendingRedistributedDebt(account))
     const entireDebt = rawDebt.add(pendingRedistributedDebt)
     let entireColl = rawColl;


### PR DESCRIPTION
Generally, `uint128` means [`340,282,366` **trillion**], it should be good enough to hold any practical collateral or debt amount as the maximum Flashloan amount for `eBTC` in `BorrowerOperations` is only `type(uint112).max`

- pack struct `Cdp` as suggested in https://github.com/ebtc-protocol/ebtc/pull/753#issue-2077573356: using `uint128` for `debt`, `coll`, `stake`, `liquidatorRewardShare`
- use `uint128` for state variable `totalStakes` (renamed to `totalStakesStorage`) and `totalCollateralSnapshot` & `totalStakesSnapshot` in `CdpManagerStorage`
- use `uint128` for state variable `feeRecipientCollShares` and `systemCollShares` & `systemDebt` in `ActivePool`
- use `uint128` for state variable `lastRedemptionTimestamp` in `CdpManagerStorage`