### PR TITLE
add safeCast for liquidatorRewardShare in CdpManager

### DIFF
--- a/packages/contracts/contracts/CdpManager.sol
+++ b/packages/contracts/contracts/CdpManager.sol
@@ -10,6 +10,7 @@ import "./Dependencies/ICollateralTokenOracle.sol";
 import "./CdpManagerStorage.sol";
 import "./Dependencies/Proxy.sol";
 import "./Dependencies/EbtcBase.sol";
+import "./Dependencies/EbtcMath.sol";
 
 /// @title CdpManager is mainly in charge of all Cdp related core processing like collateral & debt accounting, split fee calculation, redemption, etc
 /// @notice Except for redemption, end user typically will interact with BorrowerOeprations for individual Cdp actions
@@ -904,7 +905,7 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
         Cdps[_cdpId].debt = _debt;
         Cdps[_cdpId].coll = _coll;
         Cdps[_cdpId].status = Status.active;
-        Cdps[_cdpId].liquidatorRewardShares = uint128(_liquidatorRewardShares);
+        Cdps[_cdpId].liquidatorRewardShares = EbtcMath.toUint128(_liquidatorRewardShares);
 
         cdpStEthFeePerUnitIndex[_cdpId] = systemStEthFeePerUnitIndex; /// @audit We critically assume global accounting is synced here
         _updateRedistributedDebtIndex(_cdpId);

--- a/packages/contracts/contracts/Dependencies/EbtcMath.sol
+++ b/packages/contracts/contracts/Dependencies/EbtcMath.sol
@@ -6,13 +6,6 @@ library EbtcMath {
     uint256 internal constant DECIMAL_PRECISION = 1e18;
     uint256 public constant MAX_TCR = type(uint256).max;
 
-    /// credit to OpenZeppelin
-    /// Downcasting from uint256/int256 in Solidity does not revert on overflow. This can
-    /// easily result in undesired exploitation or bugs, since developers usually
-    /// assume that overflows raise errors. `SafeCast` restores this intuition by
-    /// reverting the transaction when such an operation overflows.
-    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);
-
     /* Precision for Nominal ICR (independent of price). Rationale for the value:
      *
      * - Making it “too high” could lead to overflows.
@@ -33,6 +26,7 @@ library EbtcMath {
     }
 
     /**
+     * credit to OpenZeppelin
      * @dev Returns the downcasted uint128 from uint256, reverting on
      * overflow (when the input is greater than largest uint128).
      *
@@ -43,9 +37,7 @@ library EbtcMath {
      * - input must fit into 128 bits
      */
     function toUint128(uint256 value) internal pure returns (uint128) {
-        if (value > type(uint128).max) {
-            revert SafeCastOverflowedUintDowncast(128, value);
-        }
+        require(value <= type(uint128).max, "EbtcMath: downcast to uint128 will overflow");
         return uint128(value);
     }
 

--- a/packages/contracts/contracts/Dependencies/EbtcMath.sol
+++ b/packages/contracts/contracts/Dependencies/EbtcMath.sol
@@ -6,6 +6,13 @@ library EbtcMath {
     uint256 internal constant DECIMAL_PRECISION = 1e18;
     uint256 public constant MAX_TCR = type(uint256).max;
 
+    /// credit to OpenZeppelin
+    /// Downcasting from uint256/int256 in Solidity does not revert on overflow. This can
+    /// easily result in undesired exploitation or bugs, since developers usually
+    /// assume that overflows raise errors. `SafeCast` restores this intuition by
+    /// reverting the transaction when such an operation overflows.
+    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);
+
     /* Precision for Nominal ICR (independent of price). Rationale for the value:
      *
      * - Making it “too high” could lead to overflows.
@@ -23,6 +30,23 @@ library EbtcMath {
 
     function _max(uint256 _a, uint256 _b) internal pure returns (uint256) {
         return (_a >= _b) ? _a : _b;
+    }
+
+    /**
+     * @dev Returns the downcasted uint128 from uint256, reverting on
+     * overflow (when the input is greater than largest uint128).
+     *
+     * Counterpart to Solidity's `uint128` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 128 bits
+     */
+    function toUint128(uint256 value) internal pure returns (uint128) {
+        if (value > type(uint128).max) {
+            revert SafeCastOverflowedUintDowncast(128, value);
+        }
+        return uint128(value);
     }
 
     /*


### PR DESCRIPTION
add safe downcast for `CdpManager` internal variable `LiquidatorRewardShare` from `uint256` to `uint128`

using code from openzeppelin
https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/math/SafeCast.sol#L305