### PR TITLE
revert redemption if RM is triggered

### DIFF
--- a/packages/contracts/contracts/CdpManager.sol
+++ b/packages/contracts/contracts/CdpManager.sol
@@ -488,6 +488,14 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
 
         // CEI: Send the stETH drawn to the redeemer
         activePool.transferSystemCollShares(msg.sender, totals.collSharesToRedeemer);
+
+        // final check if we not in RecoveryMode at redemption start
+        if (!_checkRecoveryModeForTCR(totals.tcrAtStart)) {
+            require(
+                !_checkRecoveryMode(totals.price),
+                "CdpManager: redemption should not trigger RecoveryMode"
+            );
+        }
     }
 
     // --- Helper functions ---

--- a/packages/contracts/test/CdpManagerTest.js
+++ b/packages/contracts/test/CdpManagerTest.js
@@ -2998,6 +2998,8 @@ contract('CdpManager', async accounts => {
     // Put Bob's Cdp below 110% ICR
     const price = dec(3714, 13);
     await priceFeed.setPrice(price)
+	
+    await openCdp({ ICR: toBN(dec(10, 18)), extraEBTCAmount: A_debt, extraParams: { from: carol } })
 
     // --- TEST --- 
     await th.syncTwapSystemDebt(contracts, ethers.provider);
@@ -3808,6 +3810,7 @@ contract('CdpManager', async accounts => {
 
 
     const A_balanceBefore = await ebtcToken.balanceOf(A)
+    await th.syncTwapSystemDebt(contracts, ethers.provider);
 
     // A redeems 10 EBTC
     await th.redeemCollateral(A, contracts, dec(10, 18), GAS_PRICE)


### PR DESCRIPTION
From @dapp-whisperer 
- check recovery mode at start of redemption
- recompute, and check at end
- if we're not in RM at the start, and we are in RM at the end, fail

In other words:
- not be in RM and stay out of it: succeed
- attempt to enter RM: fail
- in RM already and stay in RM (or leave RM): succeed