### PR TITLE
Feat/add post open invariant

### DIFF
--- a/packages/contracts/contracts/TestContracts/invariants/Properties.sol
+++ b/packages/contracts/contracts/TestContracts/invariants/Properties.sol
@@ -487,4 +487,17 @@ abstract contract Properties is BeforeAfter, PropertiesDescriptions, Asserts, Pr
     function invariant_DUMMY_01(PriceFeedTestnet priceFeedTestnet) internal view returns (bool) {
         return priceFeedTestnet.getPrice() > 0;
     }
+
+    function invariant_BO_09(
+        CdpManager cdpManager,
+        uint256 price,
+        bytes32 cdpId
+    ) internal view returns (bool) {
+        uint256 _icr = cdpManager.getSyncedICR(cdpId, price);
+        if (cdpManager.checkRecoveryMode(price)) {
+            return _icr >= cdpManager.CCR();
+        } else {
+            return _icr >= cdpManager.MCR();
+        }
+    }
 }

--- a/packages/contracts/contracts/TestContracts/invariants/PropertiesDescriptions.sol
+++ b/packages/contracts/contracts/TestContracts/invariants/PropertiesDescriptions.sol
@@ -62,6 +62,7 @@ abstract contract PropertiesDescriptions {
         "BO-05: When a borrower closes their active CDP, the gas compensation is refunded to the user";
     string constant BO_07 = "BO-07: eBTC tokens are burned upon repayment of a CDP's debt";
     string constant BO_08 = "BO-08: TCR must increase after a repayment";
+    string constant BO_09 = "BO-09: Borrower can not open a CDP that is immediately liquidatable";
 
     ///////////////////////////////////////////////////////
     // General

--- a/packages/contracts/contracts/TestContracts/invariants/TargetFunctions.sol
+++ b/packages/contracts/contracts/TestContracts/invariants/TargetFunctions.sol
@@ -776,6 +776,7 @@ abstract contract TargetFunctions is Properties {
 
             gte(_EBTCAmount, borrowerOperations.MIN_CHANGE(), GENERAL_16);
             gte(vars.cdpDebtAfter, borrowerOperations.MIN_CHANGE(), GENERAL_15);
+            require(invariant_BO_09(cdpManager, priceFeedMock.getPrice(), _cdpId), BO_09);
         } else {
             assertRevertReasonNotEqual(returnData, "Panic(17)");
         }


### PR DESCRIPTION
- "borrower can not open a CDP that is immediately liquidatable" as a post-open check for echidna & foundry tests
- add overflow test for `uint128` downcast of `liquidatorRewardShare` in `CdpManager`