### PR TITLE
Feat/twap mastery

### DIFF
--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -205,7 +205,9 @@ contract ActivePool is
         uint256 cachedSystemDebt = systemDebt + _amount;
 
         /// @audit If TWAP fails it should allow transaction to continue. Failure is preferrable to permanent DOS and can practically be mitigated by managing the redemption baseFee.
-        try this.setValueAndUpdate(EbtcMath.toUint128(cachedSystemDebt)) {} catch {}
+        try this.setValueAndUpdate(EbtcMath.toUint128(cachedSystemDebt)) {} catch {
+            twapDisabled = true;
+        }
 
         systemDebt = cachedSystemDebt;
         emit ActivePoolEBTCDebtUpdated(cachedSystemDebt);
@@ -221,7 +223,9 @@ contract ActivePool is
         uint256 cachedSystemDebt = systemDebt - _amount;
 
         /// @audit If TWAP fails it should allow transaction to continue. Failure is preferrable to permanent DOS and can practically be mitigated by managing the redemption baseFee.
-        try this.setValueAndUpdate(EbtcMath.toUint128(cachedSystemDebt)) {} catch {}
+        try this.setValueAndUpdate(EbtcMath.toUint128(cachedSystemDebt)) {} catch {
+            twapDisabled = true;
+        }
 
         systemDebt = cachedSystemDebt;
         emit ActivePoolEBTCDebtUpdated(cachedSystemDebt);

--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -204,8 +204,8 @@ contract ActivePool is
 
         uint256 cachedSystemDebt = systemDebt + _amount;
 
-        _setValue(EbtcMath.toUint128(cachedSystemDebt)); // @audit update TWAP global spot value and accumulator variable along with a timestamp
-        update(); // @audit update TWAP Observer accumulator and weighted average
+        /// @audit If TWAP fails it should allow transaction to continue. Failure is preferrable to permanent DOS and can practically be mitigated by managing the redemption baseFee.
+        try this.setValueAndUpdate(EbtcMath.toUint128(cachedSystemDebt)) {} catch {}
 
         systemDebt = cachedSystemDebt;
         emit ActivePoolEBTCDebtUpdated(cachedSystemDebt);
@@ -220,8 +220,8 @@ contract ActivePool is
 
         uint256 cachedSystemDebt = systemDebt - _amount;
 
-        _setValue(EbtcMath.toUint128(cachedSystemDebt)); // @audit update TWAP global spot value and accumulator variable along with a timestamp
-        update(); // @audit update TWAP Observer accumulator and weighted average
+        /// @audit If TWAP fails it should allow transaction to continue. Failure is preferrable to permanent DOS and can practically be mitigated by managing the redemption baseFee.
+        try this.setValueAndUpdate(EbtcMath.toUint128(cachedSystemDebt)) {} catch {}
 
         systemDebt = cachedSystemDebt;
         emit ActivePoolEBTCDebtUpdated(cachedSystemDebt);

--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -13,6 +13,7 @@ import "./Dependencies/ReentrancyGuard.sol";
 import "./Dependencies/AuthNoOwner.sol";
 import "./Dependencies/BaseMath.sol";
 import "./Dependencies/TwapWeightedObserver.sol";
+import "./Dependencies/EbtcMath.sol";
 
 /**
  * @title The Active Pool holds the collateral and EBTC debt (only accounting but not EBTC tokens) for all active cdps.
@@ -203,7 +204,7 @@ contract ActivePool is
 
         uint256 cachedSystemDebt = systemDebt + _amount;
 
-        _setValue(uint128(cachedSystemDebt)); // @audit update TWAP global spot value and accumulator variable along with a timestamp
+        _setValue(EbtcMath.toUint128(cachedSystemDebt)); // @audit update TWAP global spot value and accumulator variable along with a timestamp
         update(); // @audit update TWAP Observer accumulator and weighted average
 
         systemDebt = cachedSystemDebt;
@@ -219,7 +220,7 @@ contract ActivePool is
 
         uint256 cachedSystemDebt = systemDebt - _amount;
 
-        _setValue(uint128(cachedSystemDebt)); // @audit update TWAP global spot value and accumulator variable along with a timestamp
+        _setValue(EbtcMath.toUint128(cachedSystemDebt)); // @audit update TWAP global spot value and accumulator variable along with a timestamp
         update(); // @audit update TWAP Observer accumulator and weighted average
 
         systemDebt = cachedSystemDebt;

--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -203,12 +203,16 @@ contract ActivePool is
         _requireCallerIsBOorCdpM();
 
         uint256 cachedSystemDebt = systemDebt + _amount;
+        uint128 castedSystemDebt = EbtcMath.toUint128(cachedSystemDebt);
 
-        /// @audit If TWAP fails it should allow transaction to continue. Failure is preferrable to permanent DOS and can practically be mitigated by managing the redemption baseFee.
-        try this.setValueAndUpdate(EbtcMath.toUint128(cachedSystemDebt)) {} catch {
-            twapDisabled = true;
+        if (!twapDisabled) {
+            /// @audit If TWAP fails it should allow transaction to continue. Failure is preferrable to permanent DOS and can practically be mitigated by managing the redemption baseFee.
+            try this.setValueAndUpdate(castedSystemDebt) {} catch {
+                twapDisabled = true;
+            }
         }
 
+        /// @audit If above uint128 max, will have reverted in safeCast
         systemDebt = cachedSystemDebt;
         emit ActivePoolEBTCDebtUpdated(cachedSystemDebt);
     }
@@ -221,12 +225,16 @@ contract ActivePool is
         _requireCallerIsBOorCdpM();
 
         uint256 cachedSystemDebt = systemDebt - _amount;
+        uint128 castedSystemDebt = EbtcMath.toUint128(cachedSystemDebt);
 
-        /// @audit If TWAP fails it should allow transaction to continue. Failure is preferrable to permanent DOS and can practically be mitigated by managing the redemption baseFee.
-        try this.setValueAndUpdate(EbtcMath.toUint128(cachedSystemDebt)) {} catch {
-            twapDisabled = true;
+        if (!twapDisabled) {
+            /// @audit If TWAP fails it should allow transaction to continue. Failure is preferrable to permanent DOS and can practically be mitigated by managing the redemption baseFee.
+            try this.setValueAndUpdate(EbtcMath.toUint128(castedSystemDebt)) {} catch {
+                twapDisabled = true;
+            }
         }
 
+        /// @audit If above uint128 max, will have reverted in safeCast
         systemDebt = cachedSystemDebt;
         emit ActivePoolEBTCDebtUpdated(cachedSystemDebt);
     }

--- a/packages/contracts/contracts/CdpManager.sol
+++ b/packages/contracts/contracts/CdpManager.sol
@@ -335,7 +335,16 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
             totals.tcrAtStart = tcrAtStart;
             totals.systemCollSharesAtStart = systemCollSharesAtStart;
             totals.systemDebtAtStart = systemDebtAtStart;
-            totals.twapSystemDebtAtStart = EbtcMath._min(activePool.observe(), systemDebtAtStart); // @audit Return the smaller value of the two, bias towards a larger redemption scaling fee
+
+            try activePool.observe() returns (uint256 _twapSystemDebtAtStart) {
+                // @audit Return the smaller value of the two, bias towards a larger redemption scaling fee
+                totals.twapSystemDebtAtStart = EbtcMath._min(
+                    _twapSystemDebtAtStart,
+                    systemDebtAtStart
+                );
+            } catch {
+                totals.twapSystemDebtAtStart = systemDebtAtStart;
+            }
         }
 
         _requireTCRisNotBelowMCR(totals.price, totals.tcrAtStart);

--- a/packages/contracts/contracts/CdpManager.sol
+++ b/packages/contracts/contracts/CdpManager.sol
@@ -336,13 +336,17 @@ contract CdpManager is CdpManagerStorage, ICdpManager, Proxy {
             totals.systemCollSharesAtStart = systemCollSharesAtStart;
             totals.systemDebtAtStart = systemDebtAtStart;
 
-            try activePool.observe() returns (uint256 _twapSystemDebtAtStart) {
-                // @audit Return the smaller value of the two, bias towards a larger redemption scaling fee
-                totals.twapSystemDebtAtStart = EbtcMath._min(
-                    _twapSystemDebtAtStart,
-                    systemDebtAtStart
-                );
-            } catch {
+            if (!activePool.twapDisabled()) {
+                try activePool.observe() returns (uint256 _twapSystemDebtAtStart) {
+                    // @audit Return the smaller value of the two, bias towards a larger redemption scaling fee
+                    totals.twapSystemDebtAtStart = EbtcMath._min(
+                        _twapSystemDebtAtStart,
+                        systemDebtAtStart
+                    );
+                } catch {
+                    totals.twapSystemDebtAtStart = systemDebtAtStart;
+                }
+            } else {
                 totals.twapSystemDebtAtStart = systemDebtAtStart;
             }
         }

--- a/packages/contracts/contracts/Dependencies/TwapWeightedObserver.sol
+++ b/packages/contracts/contracts/Dependencies/TwapWeightedObserver.sol
@@ -132,6 +132,12 @@ contract TwapWeightedObserver is ITwapWeightedObserver {
         }
     }
 
+    function setValueAndUpdate(uint128 value) external {
+        require(msg.sender == address(this), "TwapWeightedObserver: Only self call");
+        _setValue(value);
+        update();
+    }
+
     function getData() external view returns (PackedData memory) {
         return data;
     }

--- a/packages/contracts/contracts/Dependencies/TwapWeightedObserver.sol
+++ b/packages/contracts/contracts/Dependencies/TwapWeightedObserver.sol
@@ -95,8 +95,9 @@ contract TwapWeightedObserver is ITwapWeightedObserver {
             return virtualAvgValue;
         }
 
-        uint256 weightedAvg = data.lastObservedAverage * (PERIOD - futureWeight);
-        uint256 weightedVirtual = virtualAvgValue * (futureWeight);
+        uint256 weightedAvg = uint256(data.lastObservedAverage) *
+            (uint256(PERIOD) - uint256(futureWeight));
+        uint256 weightedVirtual = uint256(virtualAvgValue) * (uint256(futureWeight));
 
         uint256 weightedMean = (weightedAvg + weightedVirtual) / PERIOD;
 

--- a/packages/contracts/contracts/Dependencies/TwapWeightedObserver.sol
+++ b/packages/contracts/contracts/Dependencies/TwapWeightedObserver.sol
@@ -8,6 +8,7 @@ import {ITwapWeightedObserver} from "../Interfaces/ITwapWeightedObserver.sol";
 contract TwapWeightedObserver is ITwapWeightedObserver {
     PackedData public data;
     uint128 public valueToTrack;
+    bool public twapDisabled;
 
     constructor(uint128 initialValue) {
         PackedData memory cachedData = PackedData({

--- a/packages/contracts/contracts/Interfaces/ITwapWeightedObserver.sol
+++ b/packages/contracts/contracts/Interfaces/ITwapWeightedObserver.sol
@@ -14,4 +14,6 @@ interface ITwapWeightedObserver is IBaseTwapWeightedObserver {
     function observe() external returns (uint256);
 
     function update() external;
+
+    function twapDisabled() external view returns (bool);
 }


### PR DESCRIPTION
- safe cast uint128 on max debt for TWAP to function
- cast TWAP multiplications to uint256 explicitly to avoid unexpected overflow behavior
- if TWAP `update()` reverts, activePool will continue to function
- if this revert happens, TWAP will be permanently disabled
- if TWAP  `observe()` reverts redemptions will continue to function (use systemDebtAtStart)

once twap is disabled, update() and observe() calls will be skipped and we'll degrade to the previous functionality before the mitigation.

flash loan pushing to max debt should not revert due to TWAP math, but also due to safeCast being outside the try/catch block. 

note that we will have assumptions around max plausible debt in the system (besides during flash loan) during bug bounty.
it will be notably lower than uint128.max.