### PR TITLE
Adding TWAP overflow unit test and invariant

### DIFF
--- a/packages/contracts/contracts/TestContracts/invariants/Properties.sol
+++ b/packages/contracts/contracts/TestContracts/invariants/Properties.sol
@@ -376,6 +376,10 @@ abstract contract Properties is BeforeAfter, PropertiesDescriptions, Asserts, Pr
             sumOfColl + vars.cumulativeCdpsAtTimeOfRebase >= _systemCollShares;
     }
 
+    function invariant_GENERAL_19(ActivePool activePool) internal view returns (bool) {
+        return !activePool.twapDisabled();
+    }
+
     function invariant_GENERAL_08(
         CdpManager cdpManager,
         SortedCdps sortedCdps,

--- a/packages/contracts/contracts/TestContracts/invariants/PropertiesDescriptions.sol
+++ b/packages/contracts/contracts/TestContracts/invariants/PropertiesDescriptions.sol
@@ -98,6 +98,7 @@ abstract contract PropertiesDescriptions {
         "GENERAL-17: Sum of synced debt values of all Cdps + the stored debt redistribution error accumulator should never be more than the total system debt + 1";
     string constant GENERAL_18 =
         "GENERAL-18: Sum of synced coll shares of all Cdps - cumulative errors should never be more than _systemCollShares";
+    string constant GENERAL_19 = "GENERAL-19: TWAP should never be disabled";
 
     ///////////////////////////////////////////////////////
     // Redemptions

--- a/packages/contracts/contracts/TestContracts/invariants/echidna/EchidnaProperties.sol
+++ b/packages/contracts/contracts/TestContracts/invariants/echidna/EchidnaProperties.sol
@@ -119,6 +119,10 @@ abstract contract EchidnaProperties is TargetContractSetup, Properties {
         return invariant_GENERAL_18(cdpManager, sortedCdps, priceFeedMock, collateral);
     }
 
+    function echidna_GENERAL_19() public returns (bool) {
+        return invariant_GENERAL_19(activePool);
+    }
+
     function echidna_LS_01() public returns (bool) {
         return
             invariant_LS_01(

--- a/packages/contracts/foundry_test/ActivePool.twapAcc.t.sol
+++ b/packages/contracts/foundry_test/ActivePool.twapAcc.t.sol
@@ -120,6 +120,7 @@ contract ActivePoolTwapAccTest is eBTCBaseFixture {
         vm.expectEmit(false, false, false, false);
         emit TwapDisabled();
         borrowerOperations.openCdp(0.1e18, bytes32(0), bytes32(0), 5e18);
+        vm.stopPrank();
 
         assertEq(activePool.twapDisabled(), true);
     }

--- a/packages/contracts/foundry_test/ActivePool.twapAcc.t.sol
+++ b/packages/contracts/foundry_test/ActivePool.twapAcc.t.sol
@@ -111,6 +111,7 @@ contract ActivePoolTwapAccTest is eBTCBaseFixture {
 
         _openTestCDP(users[0], 5e18, 0.1e18);
 
+        // force TWAP to overflow
         vm.warp(uint256(type(uint64).max) + 1);
 
         dealCollateral(users[1], 5e18);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new invariant to ensure the Time-Weighted Average Price (TWAP) cannot be disabled, enhancing the system's reliability.
- **Tests**
	- Implemented a new test to validate the TWAP functionality cannot be erroneously disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->