### PR TITLE
fix dust surplus claim in recovery mode liquidation

### DIFF
--- a/packages/contracts/contracts/LiquidationLibrary.sol
+++ b/packages/contracts/contracts/LiquidationLibrary.sol
@@ -334,15 +334,20 @@ contract LiquidationLibrary is CdpManagerStorage {
                 _totalColToSend
             );
             if (_collSurplus > 0) {
-                collSurplusPool.increaseSurplusCollShares(
-                    _recoveryState.cdpId,
-                    _borrower,
-                    _collSurplus,
-                    0
-                );
-                _recoveryState.totalSurplusCollShares =
-                    _recoveryState.totalSurplusCollShares +
-                    _collSurplus;
+                if (_checkICRAgainstMCR(_recoveryState.ICR)) {
+                    _cappedColPortion = _collSurplus + _cappedColPortion;
+                    _collSurplus = 0;
+                } else {
+                    collSurplusPool.increaseSurplusCollShares(
+                        _recoveryState.cdpId,
+                        _borrower,
+                        _collSurplus,
+                        0
+                    );
+                    _recoveryState.totalSurplusCollShares =
+                        _recoveryState.totalSurplusCollShares +
+                        _collSurplus;
+                }
             }
             if (_debtToRedistribute > 0) {
                 _totalDebtToBurn = _totalDebtToBurn - _debtToRedistribute;

--- a/packages/contracts/contracts/TestContracts/invariants/BeforeAfter.sol
+++ b/packages/contracts/contracts/TestContracts/invariants/BeforeAfter.sol
@@ -10,6 +10,8 @@ abstract contract BeforeAfter is BaseStorageVariables {
     using Pretty for bool;
 
     struct Vars {
+        uint256 userSurplusBefore;
+        uint256 userSurplusAfter;
         uint256 valueInSystemBefore;
         uint256 valueInSystemAfter;
         uint256 nicrBefore;
@@ -82,6 +84,9 @@ abstract contract BeforeAfter is BaseStorageVariables {
     function _before(bytes32 _cdpId) internal {
         vars.priceBefore = priceFeedMock.fetchPrice();
 
+        address ownerToCheck = sortedCdps.getOwnerAddress(_cdpId);
+        vars.userSurplusBefore = collSurplusPool.getSurplusCollShares(ownerToCheck);
+
         (uint256 debtBefore, ) = cdpManager.getSyncedDebtAndCollShares(_cdpId);
 
         vars.nicrBefore = _cdpId != bytes32(0) ? crLens.quoteRealNICR(_cdpId) : 0;
@@ -140,6 +145,9 @@ abstract contract BeforeAfter is BaseStorageVariables {
     }
 
     function _after(bytes32 _cdpId) internal {
+        address ownerToCheck = sortedCdps.getOwnerAddress(_cdpId);
+        vars.userSurplusAfter = collSurplusPool.getSurplusCollShares(ownerToCheck);
+
         vars.priceAfter = priceFeedMock.fetchPrice();
 
         vars.nicrAfter = _cdpId != bytes32(0) ? crLens.quoteRealNICR(_cdpId) : 0;

--- a/packages/contracts/contracts/TestContracts/invariants/TargetFunctions.sol
+++ b/packages/contracts/contracts/TestContracts/invariants/TargetFunctions.sol
@@ -226,6 +226,7 @@ abstract contract TargetFunctions is Properties {
         _before(_cdpId);
 
         uint256 _icrToLiq = cdpManager.getSyncedICR(_cdpId, priceFeedMock.getPrice());
+
         (success, returnData) = actor.proxy(
             address(cdpManager),
             abi.encodeWithSelector(CdpManager.liquidate.selector, _cdpId)
@@ -234,6 +235,12 @@ abstract contract TargetFunctions is Properties {
         _after(_cdpId);
 
         if (success) {
+            // SURPLUS-CHECK-1 | The surplus is capped at 4 wei | NOTE: Proxy of growth, storage var would further refine
+            if (_icrToLiq <= cdpManager.MCR()) {
+                gte(vars.collSurplusPoolBefore + 4, vars.collSurplusPoolAfter, "SURPLUS-CHECK-1");
+                gte(vars.userSurplusBefore + 4, vars.userSurplusAfter, "SURPLUS-CHECK-2");
+            }
+
             // if ICR >= TCR then we ignore
             // We could check that Liquidated is not above TCR
             if (
@@ -421,6 +428,9 @@ abstract contract TargetFunctions is Properties {
         _after(bytes32(0));
 
         if (success) {
+            // SURPLUS-CHECK-1 | The surplus is capped at 4 wei | NOTE: We use Liquidate for the exact CDP check
+            gte(vars.collSurplusPoolBefore + 4, vars.collSurplusPoolAfter, "SURPLUS-CHECK-1");
+
             Cdp[] memory cdpsAfter = _getCdpIdsAndICRs();
 
             Cdp[] memory cdpsLiquidated = _cdpIdsAndICRsDiff(cdpsBefore, cdpsAfter);

--- a/packages/contracts/foundry_test/EchidnaToFoundry.t.sol
+++ b/packages/contracts/foundry_test/EchidnaToFoundry.t.sol
@@ -25,13 +25,16 @@ contract EToFoundry is
 {
     modifier setup() override {
         _;
+        address sender = uint160(msg.sender) % 3 == 0 ? address(USER1) : uint160(msg.sender) % 3 == 1
+            ? address(USER2)
+            : address(USER3);
+        actor = actors[sender];
     }
 
     function setUp() public {
         _setUp();
         _setUpActors();
-        actor = actors[USER1];
-        vm.startPrank(address(actor));
+        actor = actors[address(USER1)];
     }
 
     function _checkTotals() internal {
@@ -221,9 +224,17 @@ contract EToFoundry is
     function _logStakes() internal {
         bytes32 currentCdp = sortedCdps.getFirst();
 
+        console2.log("=== LogStakes ===");
+
+        uint256 currentPrice = priceFeedMock.fetchPrice();
+        uint256 currentPricePerShare = collateral.getPooledEthByShares(1 ether);
+        console2.log("currentPrice", currentPrice);
+        console2.log("currentPricePerShare", currentPricePerShare);
+
         while (currentCdp != bytes32(0)) {
             emit DebugBytes32(currentCdp);
             console2.log("CdpId", vm.toString(currentCdp));
+            console2.log("===============================");
             console2.log("cdpManager.getCdpStake(currentCdp)", cdpManager.getCdpStake(currentCdp));
             console2.log(
                 "cdpManager.getSyncedCdpCollShares(currentCdp)",
@@ -239,7 +250,16 @@ contract EToFoundry is
                 "cdpManager.getSyncedNominalICR(currentCdp)",
                 cdpManager.getSyncedNominalICR(currentCdp)
             );
+            console2.log(
+                "cdpManager.getCachedICR(currentCdp, currentPrice)",
+                cdpManager.getCachedICR(currentCdp, currentPrice)
+            );
+            console2.log(
+                "cdpManager.getSyncedICR(currentCdp, currentPrice)",
+                cdpManager.getSyncedICR(currentCdp, currentPrice)
+            );
             currentCdp = sortedCdps.getNext(currentCdp);
+            console2.log("");
         }
 
         console2.log(


### PR DESCRIPTION
- add POC from immunefi contest for flashloan fee escape due to division loss
- add fix to avoid dust surplus in recovery mode liquidation https://gist.github.com/dapp-whisperer/c023eacc977e0f07c0c81a288b5cf090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced liquidation process to handle surplus collateral more effectively based on internal collateral ratios.
	- Introduced new test scenarios to validate the improved liquidation logic and ensure security against flash loan attacks.
	- Improved surplus management and added surplus cap checks for collateral and user pools during liquidation.
	- Refactored code to include additional conditional assignments and logging for better stake management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->